### PR TITLE
better handling of XSLT inside jars

### DIFF
--- a/src/modules/indexing/src/main/java/org/geonetwork/indexing/IndexingRecordService.java
+++ b/src/modules/indexing/src/main/java/org/geonetwork/indexing/IndexingRecordService.java
@@ -10,8 +10,8 @@ import static java.util.stream.Collectors.groupingBy;
 import static org.geonetwork.index.model.record.IndexRecordFieldNames.OP_PREFIX;
 import static org.geonetwork.index.model.record.IndexRecordFieldNames.VALID;
 
-import java.io.File;
 import java.io.IOException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -80,13 +80,13 @@ public class IndexingRecordService {
     /** Collect properties from the database metadata and apply XSLT to extract fields from XML document.. */
     public IndexRecords collectProperties(String schema, List<Metadata> schemaRecords) {
         String indexingXsltFileName = String.format("indexing/xslt/%s.xsl", schema);
-        File indexingXsltFile = null;
+        URL indexingXsltFile = null;
         try {
-            indexingXsltFile = new ClassPathResource(indexingXsltFileName).getFile();
+            indexingXsltFile = new ClassPathResource(indexingXsltFileName).getURL();
         } catch (IOException ioSchemaFileException) {
             if (schema.startsWith("iso19")) {
                 try {
-                    indexingXsltFile = new ClassPathResource("xslt/indexing/iso.xsl").getFile();
+                    indexingXsltFile = new ClassPathResource("xslt/indexing/iso.xsl").getURL();
                 } catch (IOException isoFileException) {
                     // Should not happen
                 }

--- a/src/shared/testing/pom.xml
+++ b/src/shared/testing/pom.xml
@@ -48,7 +48,6 @@
         <artifactId>maven-jar-plugin</artifactId>
         <executions>
           <execution>
-            <phase>validate</phase>
             <goals>
               <goal>test-jar</goal>
             </goals>

--- a/src/shared/testing/pom.xml
+++ b/src/shared/testing/pom.xml
@@ -48,6 +48,7 @@
         <artifactId>maven-jar-plugin</artifactId>
         <executions>
           <execution>
+            <phase>compile</phase>
             <goals>
               <goal>test-jar</goal>
             </goals>

--- a/src/shared/testing/pom.xml
+++ b/src/shared/testing/pom.xml
@@ -54,6 +54,10 @@
             </goals>
           </execution>
         </executions>
+        <configuration>
+          <forceCreation>true</forceCreation>
+          <skip>false</skip>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/src/shared/testing/pom.xml
+++ b/src/shared/testing/pom.xml
@@ -48,7 +48,7 @@
         <artifactId>maven-jar-plugin</artifactId>
         <executions>
           <execution>
-            <phase>compile</phase>
+            <phase>validate</phase>
             <goals>
               <goal>test-jar</goal>
             </goals>

--- a/src/shared/testing/src/test/resources/tests/simpleinclude/README.md
+++ b/src/shared/testing/src/test/resources/tests/simpleinclude/README.md
@@ -1,0 +1,6 @@
+See XsltUtilTest.java
+
+This requires that the input XSLT is loaded via a JAR via a URL.
+
+This is how the main application will be loading XSLT resources, so its important the test case use the jar:...!... protocol.
+

--- a/src/shared/testing/src/test/resources/tests/simpleinclude/test-include.xsl
+++ b/src/shared/testing/src/test/resources/tests/simpleinclude/test-include.xsl
@@ -1,0 +1,19 @@
+<!--
+
+    (c) 2003 Open Source Geospatial Foundation - all rights reserved
+    This code is licensed under the GPL 2.0 license,
+    available at the root application directory.
+
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns:gn-fn-index="https://www.geonetwork-opensource.org/xslt/functions/index"
+                xmlns:util="https://geonetwork-opensource.org/xsl-extension"
+                version="3.0"
+                exclude-result-prefixes="#all">
+
+  <xsl:variable name="test_include_xsl" select="'from-test-include.xsl'"/>
+
+
+</xsl:stylesheet>

--- a/src/shared/testing/src/test/resources/tests/simpleinclude/test.xsl
+++ b/src/shared/testing/src/test/resources/tests/simpleinclude/test.xsl
@@ -1,0 +1,21 @@
+<!--
+
+    (c) 2003 Open Source Geospatial Foundation - all rights reserved
+    This code is licensed under the GPL 2.0 license,
+    available at the root application directory.
+
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                version="3.0"
+                exclude-result-prefixes="#all"
+                xmlns:gc="http://geocat.net/">
+  <xsl:import href="test-include.xsl"/>
+
+  <xsl:variable name="test_xsl" select="'from-test.xsl'"/>
+
+  <xsl:template match="/">
+    <xsl:comment>comment from  <xsl:value-of select="$test_xsl"/> </xsl:comment>
+    <xsl:comment>comment from  <xsl:value-of select="$test_include_xsl"/> </xsl:comment>
+    <gc:geocat>Hello World TestCase</gc:geocat>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/shared/utility/pom.xml
+++ b/src/shared/utility/pom.xml
@@ -52,5 +52,20 @@
       <artifactId>gn-schemas-model</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.geonetwork</groupId>
+      <artifactId>gn-testing</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
+
 </project>

--- a/src/shared/utility/pom.xml
+++ b/src/shared/utility/pom.xml
@@ -64,6 +64,7 @@
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
+      <classifier>tests</classifier>
     </dependency>
 
   </dependencies>

--- a/src/shared/utility/pom.xml
+++ b/src/shared/utility/pom.xml
@@ -63,8 +63,8 @@
       <artifactId>gn-testing</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
-      <scope>test</scope>
       <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
 
   </dependencies>

--- a/src/shared/utility/src/main/java/org/geonetwork/utility/xml/XsltUtil.java
+++ b/src/shared/utility/src/main/java/org/geonetwork/utility/xml/XsltUtil.java
@@ -7,11 +7,11 @@
 package org.geonetwork.utility.xml;
 
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import java.io.File;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.net.URL;
 import java.util.Map;
 import javax.xml.stream.XMLStreamWriter;
 import javax.xml.transform.stream.StreamSource;
@@ -36,7 +36,7 @@ public class XsltUtil {
      */
     public static <T> T transformObjectToObject(
             Object inputObject,
-            File xsltFile,
+            URL xsltFile,
             Class<T> objectClass,
             Map<QName, net.sf.saxon.s9api.XdmValue> xslParameters) {
         XmlMapper xmlMapper = new XmlMapper();
@@ -53,7 +53,7 @@ public class XsltUtil {
     /** Transform Object to String. */
     public static <T> String transformObjectToString(
             Object inputObject,
-            File xsltFile,
+            URL xsltFile,
             Class<T> objectClass,
             Map<QName, net.sf.saxon.s9api.XdmValue> xslParameters) {
         XmlMapper xmlMapper = new XmlMapper();
@@ -64,46 +64,6 @@ public class XsltUtil {
             log.atError().log(e.getMessage());
             throw new RuntimeException(e);
         }
-    }
-
-    /** Transform XML string to Object. */
-    public static <T> T transformXmlToObject(
-            String inputXmlString,
-            File xsltFile,
-            Class<T> objectClass,
-            Map<QName, net.sf.saxon.s9api.XdmValue> xslParameters) {
-        String xmlAsString = transformXmlAsString(inputXmlString, xsltFile, xslParameters);
-        XmlMapper xmlMapper = new XmlMapper();
-        try {
-            return xmlMapper.readValue(xmlAsString, objectClass);
-        } catch (Exception e) {
-            log.atError().log(e.getMessage());
-            throw new RuntimeException(e);
-        }
-        //    return null;
-        //    TransformerFactory factory = XsltTransformerFactory.get();
-        //    StreamSource xslt = new StreamSource(xsltFile);
-        //    StreamSource text = new StreamSource(new StringReader(inputXmlString));
-        //    try {
-        //      JAXBContext jaxbContext = JAXBContext.newInstance(objectClass);
-        //      JAXBResult result = new JAXBResult(jaxbContext);
-        //
-        //      Transformer transformer = factory.newTransformer(xslt);
-        //      transformer.transform(text, result);
-        //      Object o = result.getResult();
-        //      if (objectClass.isInstance(o)) {
-        //        return (T) o;
-        //      } else {
-        //        return null;
-        //      }
-        //    } catch (TransformerConfigurationException e) {
-        //      e.printStackTrace();
-        //    } catch (TransformerException e2) {
-        //      e2.printStackTrace();
-        //    } catch (JAXBException e) {
-        //      throw new RuntimeException(e);
-        //    }
-        //    return null;
     }
 
     /** Transform XML string and write result to XMLStreamWriter. */
@@ -154,12 +114,12 @@ public class XsltUtil {
 
     /** Transform XML string as String. */
     public static String transformXmlAsString(
-            String inputXmlString, File xsltFile, Map<QName, net.sf.saxon.s9api.XdmValue> xslParameters) {
+            String inputXmlString, URL xsltFile, Map<QName, net.sf.saxon.s9api.XdmValue> xslParameters) {
         try {
             Processor proc = XsltTransformerFactory.getProcessor();
             XsltCompiler compiler = proc.newXsltCompiler();
 
-            XsltExecutable xsl = compiler.compile(new StreamSource(xsltFile));
+            XsltExecutable xsl = compiler.compile(new StreamSource(xsltFile.toString()));
             Xslt30Transformer transformer = xsl.load30();
             if (xslParameters != null) {
                 transformer.setStylesheetParameters(xslParameters);

--- a/src/shared/utility/src/test/java/org/geonetwork/utility/xml/XsltUtilTest.java
+++ b/src/shared/utility/src/test/java/org/geonetwork/utility/xml/XsltUtilTest.java
@@ -14,7 +14,7 @@ package org.geonetwork.utility.xml;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.net.URL;
+import java.net.URI;
 import java.util.HashMap;
 import org.geonetwork.GeonetworkTestingApplication;
 import org.junit.Test;
@@ -42,7 +42,7 @@ public class XsltUtilTest {
         //        be get getting the XSLTs from inside a JAR.  There were old problems where the assumption,
         //        incorrectly, was getting the XSLT from a file.
         assertEquals("jar", myxsl.getProtocol());
-        myxsl = new URL(myxsl.toString()); // be explicit about the URL
+        myxsl = (new URI(myxsl.toString())).toURL(); // be explicit about the URL
 
         var result = XsltUtil.transformXmlAsString("<dave>hi</dave>", myxsl, new HashMap<>());
 

--- a/src/shared/utility/src/test/java/org/geonetwork/utility/xml/XsltUtilTest.java
+++ b/src/shared/utility/src/test/java/org/geonetwork/utility/xml/XsltUtilTest.java
@@ -42,7 +42,7 @@ public class XsltUtilTest {
         //        be get getting the XSLTs from inside a JAR.  There were old problems where the assumption,
         //        incorrectly, was getting the XSLT from a file.
         assertEquals("jar", myxsl.getProtocol());
-        myxsl = (new URI(myxsl.toString())).toURL(); // be explicit about the URL
+        myxsl = new URI(myxsl.toString()).toURL(); // be explicit about the URL
 
         var result = XsltUtil.transformXmlAsString("<dave>hi</dave>", myxsl, new HashMap<>());
 

--- a/src/shared/utility/src/test/java/org/geonetwork/utility/xml/XsltUtilTest.java
+++ b/src/shared/utility/src/test/java/org/geonetwork/utility/xml/XsltUtilTest.java
@@ -1,0 +1,52 @@
+/*
+ * (c) 2003 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license,
+ * available at the root application directory.
+ */
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license,
+ * available at the root application directory.
+ */
+
+package org.geonetwork.utility.xml;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URL;
+import java.util.HashMap;
+import org.geonetwork.GeonetworkTestingApplication;
+import org.junit.Test;
+
+public class XsltUtilTest {
+
+    /**
+     * runs a simple test where is "executes" a trivial XSLT that xsl:includes another XSLT.
+     *
+     * <p>The XSLT must be inside a JAR (jar:file:...location of jar...!path/to/xslt.xsl)
+     *
+     * <p>XSLT comes from the "gn-testing" module.
+     *
+     * @throws Exception typically a parsing error
+     */
+    @Test
+    public void test_load_from_url_with_includes() throws Exception {
+
+        var myxsl = GeonetworkTestingApplication.class.getClassLoader().getResource("tests/simpleinclude/test.xsl");
+
+        // this might fail if you are running inside your IDE.  Run from maven directly.
+        // your IDE should support this.
+        // ISSUE: ide will often include resources directly from the filesystem, instead of from
+        //        inside the JAR.  When deploying GN5 in a real environment, the system will almost certainly
+        //        be get getting the XSLTs from inside a JAR.  There were old problems where the assumption,
+        //        incorrectly, was getting the XSLT from a file.
+        assertEquals("jar", myxsl.getProtocol());
+        myxsl = new URL(myxsl.toString()); // be explicit about the URL
+
+        var result = XsltUtil.transformXmlAsString("<dave>hi</dave>", myxsl, new HashMap<>());
+
+        assertTrue(result.contains("from-test-include.xsl"));
+        assertTrue(result.contains("from-test.xsl"));
+    }
+}


### PR DESCRIPTION
I noticed that there were issues indexing.

Looking through the problem, the root cause is that the `iso.xsl` and `iso19139.xsl` are package inside JARs.

In some circumstances - especially when running in an IDE - the resources are real filesytem files.  If you are running "normally" (i.e. via maven) these resources will be inside a jar (URLs like `jar:file:path/to/jar.jar!/path/to/resource`).

Since the old code was using `resource.getFile()`, this would work if running exploded (i.e. in the IDE with real filesystem files), but fail if running with the resources inside jars.

This is a very minor fix that, instead of files, uses URLs.  This will work with Filesystem file as well as jar:url.

The test case is a bit complex because of how maven does tests - it will, typically, do them exploded (i.e. resources are real filesystem files).  I tried having tests create a test-jar, however, maven isn't very good at executing them.
So, I put the test cases's .xsl inside the `gn-testing` project.  Then, I use its test-case jar as a dependency for the `gn-utility` module.  

The test case verifies that its a "jar:" url and that `xsl:includes` are working correctly.   