### PR TITLE
resolving differences with gn-microservices IndexRecord

### DIFF
--- a/src/shared/index-model/src/main/java/org/geonetwork/index/model/record/IndexRecord.java
+++ b/src/shared/index-model/src/main/java/org/geonetwork/index/model/record/IndexRecord.java
@@ -138,6 +138,7 @@ public class IndexRecord {
      *             "link": "http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/noLimitations"
      * </pre>
      */
+
     @JsonIgnore
     @Singular("constraints")
     final Map<String, List<Map<String, String>>> constraints = new HashMap<>();
@@ -277,9 +278,10 @@ public class IndexRecord {
      * <pre>
      *     resourceTitleObject: {
      *         default: "Organisation de la protection civile dans
-     *         le canton de Fribourg - Organisation des Zivilschutzes im Kanton Freiburg",
-     *             langfre: "Organisation de la protection civile dans le canton de Fribourg
-     *             - Organisation des Zivilschutzes im Kanton Freiburg"
+     *                    le canton de Fribourg - Organisation des Zivilschutzes im Kanton Freiburg",
+     *         langfre: "Organisation de la protection civile dans le canton de Fribourg
+     *                   - Organisation des Zivilschutzes im Kanton Freiburg"
+     *    }
      * </pre>
      */
     @JsonProperty(IndexRecordFieldNames.RESOURCE_TITLE)
@@ -379,7 +381,11 @@ public class IndexRecord {
     // eg. iso19139
     private String documentStandard;
 
-    // eg. ISO 19119/2005
+    //eg "iso19139"
+    private String schema;
+
+
+  // eg. ISO 19119/2005
     @JsonProperty(IndexRecordFieldNames.STANDARD_NAME)
     private Map<String, String> standardName;
 


### PR DESCRIPTION
### WIP - put here now so others can see what I am doing!!
 

I've noticed some differences between the `IndexRecord` class in geonetwork-microservices ("gn-u") and the one, here, in GN5.

I'm going to try to resolve some of the differences, and likely add some test cases.

### Looking at geonetwork-microservices/IndexRecord

1. GN5 doesn't have field "schema" thats in gn-u

     I don't think this is in the actual ES index - i dont see it created in in the GN4 schemas `index.xsl`. 
    There is one in this test document - https://github.com/geonetwork/geonetwork-microservices/blob/main/modules/library/common-index-model/src/test/resources/index-document.json#L337

  ACTION: none (NOT in gn5).

2. GN5 doesn't have field "internalId" thats in gn-u

  gn-u:      `this.setInternalId(r.getId());`

    This is likely a reference to "_id" in the ES document.

  I think this is okay to not have in GN5 - use `metadataIdentifier` instead.

  ACTION: none (NOT in gn5).

3. `docType` is string in gn-u, but enum ( `metadata`,`features`) ing GN5

    ACTION: verify that  `metadata` or `features` are the only possible values for this.

4. `standardName` is string in gn-u, but `Map<string,string>` in GN5

```
"standardNameObject" : {
    "default" : "ISO 19115-3",
    "langfre" : "ISO 19115-3"
  },
```

```
"documentStandard": "iso19139",
```

This is a bit more complex - it looks like a mistake.

I wasn't able to see this in GN4 (other than a reference `"standardNameObject.default"` in ESFacet.java - it only appears to be in GN5, and there doesn't appear to be anything in the `index.xls` xforms that create it.  I think this should be removed and people should be using the `documentStandard` field.

ACTION: remove from GN5

5. `hasOverview` - this appears to be only apart of the `ISO 19115-3` in GN4 and not created in GN5.

ACTION: remove from GN5 (just see if `overviews` is empty).

6. `isMultilingual` is in GN4 and GN-u, but not in GN5

 ACTION: remove from GN5 (or, alternatively, add to the GN5 `index.xsl`).

7. `OrgObject` (GN5) vs `org` (GN4/GN-u)

    It looks like GN5 uses "OrgObject" (List of `Map<String,String>`) while GN4/GN-u uses "org" (List of `String`).

    I expect this is for multi-lingual support.

   However, this doesn't seem to be populated in the GN5.  This looks like an oversight in the gn5 `indexing.xsl`

   GN5 does do some special handling of `*OrgObject`, however, I don't think they are every processed.

ACTION: Needs discussion

8. `OrgForResource` (GN4) not in GN5. 
  
    This could be some GN5 special handling for `*OrgObject` fields.  However, its unclear how they are processed.
    I think they get injected into the `resourceByRole` field.

9. `Contact` (GN4/GN-u) `ContactByRole` (GN5). (also, `contactForResource`)

     GN4/GN-u are `List<Contact>`, while GN5 is a `Map<String,List<Contact>>`

     GN5 looks at different types of contacts and groups them.

   ACTION: NOTHING (leave as is)
   

10. `Overview.java` is slightly different in GN-u/GN5.

GN-u : 
```
 @JsonProperty("text")
  Map<String, String> label = new HashMap<>();
```

GN5:
```
    @JsonProperty("nameObject")
    Map<String, String> name;
```

ACTION: needs discussion and verification

11. `resolutionScaleDenominator` - `List<String>` in GN-u, `List<Float>` GN5.

ACTION: none - shouldn't make any real difference.

12. `location` - `Coordinate` GN-u, `String` GN5.

ACTION: change GN5 to be `Coordinate`

13. `geometries` - `Object` GN-u, `String` GN5.

ACTION: update GN5 to have the `Object` (or a more concrete java object) instead of having a big string.

