### PR TITLE
GN5 Proxy to GN4: proxy filter predicate for GN4 portals

### DIFF
--- a/src/apps/geonetwork/src/main/java/org/geonetwork/gn4proxyprediates/GnPortalPredicate.java
+++ b/src/apps/geonetwork/src/main/java/org/geonetwork/gn4proxyprediates/GnPortalPredicate.java
@@ -1,0 +1,79 @@
+/*
+ * (c) 2003 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license,
+ * available at the root application directory.
+ */
+package org.geonetwork.gn4proxyprediates;
+
+import io.micrometer.common.util.StringUtils;
+import java.util.List;
+import org.geonetwork.domain.repository.SourceRepository;
+import org.geonetwork.utility.ApplicationContextProvider;
+import org.springframework.cloud.gateway.server.mvc.common.Shortcut;
+import org.springframework.context.ApplicationContext;
+import org.springframework.web.servlet.function.RequestPredicate;
+
+/**
+ * Looks at the incoming request and sees if it looks like a GN4 request to one of the GN portals (as defined in
+ * DB:`sources` table). Please see the uuid field in the `sources` table.
+ *
+ * <p>routes: - id: geonetwork_route uri: ${geonetwork.core.url} predicates: - isGnPortalRequest=/geonetwork filters: -
+ * addSimpleGn4SecurityHeader=gn5.to.gn4.trusted.json.auth
+ *
+ * <p>This will match `/geonetwork/srv/...` and `/geonetwork/srv` (default portal name) If you have a portal with ID
+ * (uuid) 'dave', then it will also match `/geonetwork/dave/...` and `/geonetwork/dave`.
+ *
+ * <p>If there is no source called "home", then `/geonetwork/home/...` will NOT MATCH.
+ */
+public class GnPortalPredicate {
+
+    static ApplicationContext applicationContext = ApplicationContextProvider.getApplicationContext();
+
+    /*
+     * This does the matching to things like '/geonetwork/<portal uuid>/...'.
+     * This also matches the default portal '/geonetwork/srv'.
+     *
+     * @param contextPath - typically "/geonetwork"
+     * @return true if request path is like "/geonetwork/PORTAL-UUID/..."
+     */
+    @Shortcut
+    public static RequestPredicate isGnPortalRequest(String contextPath) {
+        return request -> {
+            if (!request.path().startsWith(contextPath + "/")) {
+                return false; // not to "/geonetwork/..."
+            }
+            // remove "/geonetwork" from start
+            var path = request.path().substring(contextPath.length());
+            if (path.startsWith("/")) {
+                path = path.substring(1);
+            }
+            if (StringUtils.isBlank(path)) {
+                return false;
+            }
+            // portalName: "/geonetwork/srv/..." --> "srv"
+            var portalName = path;
+            if (portalName.contains("/")) {
+                portalName = portalName.substring(0, portalName.indexOf("/"));
+            }
+            if (portalName.equals("srv")) {
+                return true; // this is the default portal
+            }
+            var portalIds = portalIds();
+            return portalIds.contains(portalName);
+        };
+    }
+
+    /**
+     * Get the IDs (UUID) of all the portals (DB: `sources` tables).
+     *
+     * <p>Note, in general, the UUID of the main portal will be GUID.
+     *
+     * @return the IDs (UUID) of the all portal (DB: `sources` tables)
+     */
+    static List<String> portalIds() {
+        var sourceRepository = applicationContext.getBean(SourceRepository.class);
+        var portalNames =
+                sourceRepository.findAll().stream().map(x -> x.getUuid()).toList();
+        return portalNames;
+    }
+}

--- a/src/apps/geonetwork/src/main/java/org/geonetwork/gn4proxyprediates/GnPortalPredicateProvider.java
+++ b/src/apps/geonetwork/src/main/java/org/geonetwork/gn4proxyprediates/GnPortalPredicateProvider.java
@@ -1,0 +1,21 @@
+/*
+ * (c) 2003 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license,
+ * available at the root application directory.
+ */
+package org.geonetwork.gn4proxyprediates;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collection;
+import org.springframework.cloud.gateway.server.mvc.predicate.PredicateSupplier;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GnPortalPredicateProvider implements PredicateSupplier {
+
+    @Override
+    public Collection<Method> get() {
+        return Arrays.asList(GnPortalPredicate.class.getMethods());
+    }
+}

--- a/src/apps/geonetwork/src/main/resources/META-INF/spring.factories
+++ b/src/apps/geonetwork/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,4 @@
 org.springframework.cloud.gateway.server.mvc.filter.FilterSupplier=org.geonetwork.gn4forwarding.SimpleGn4SecurityHeaderAppenderSupplier,org.geonetwork.gn4forwarding.SimpleJwtGn4SecurityHeaderAppenderSupplier
+org.springframework.cloud.gateway.server.mvc.predicate.PredicateSupplier=org.geonetwork.gn4proxyprediates.GnPortalPredicateProvider
 
 

--- a/src/apps/geonetwork/src/test/java/org/geonetwork/gn4proxyprediates/GnPortalPredicateTest.java
+++ b/src/apps/geonetwork/src/test/java/org/geonetwork/gn4proxyprediates/GnPortalPredicateTest.java
@@ -1,0 +1,109 @@
+/*
+ * (c) 2003 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license,
+ * available at the root application directory.
+ */
+package org.geonetwork.gn4proxyprediates;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+import org.geonetwork.domain.Source;
+import org.geonetwork.domain.repository.SourceRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.web.servlet.function.ServerRequest;
+
+/** Simple tests for GnPortalPredicate. */
+public class GnPortalPredicateTest {
+
+    /** this tests a Path that isn't to "/geonetwork" */
+    @Test
+    public void testNotGN() {
+        setupGnPortalPredicate(Arrays.asList());
+
+        var predicate = GnPortalPredicate.isGnPortalRequest("/geoserver");
+
+        assertEquals(false, predicate.test(createRequest("/abc")));
+        assertEquals(false, predicate.test(createRequest("/abc/")));
+    }
+
+    /** tests the "main" portal (`srv`). */
+    @Test
+    public void testSrv() {
+        setupGnPortalPredicate(Arrays.asList());
+
+        var predicate = GnPortalPredicate.isGnPortalRequest("/geoserver");
+
+        assertEquals(true, predicate.test(createRequest("/geoserver/srv")));
+        assertEquals(true, predicate.test(createRequest("/geoserver/srv/")));
+    }
+
+    /** Tests a good source (portal uuid) - one that exists. */
+    @Test
+    public void testGoodSource() {
+        setupGnPortalPredicate(Arrays.asList("abc", "def", "ghi"));
+
+        var predicate = GnPortalPredicate.isGnPortalRequest("/geoserver");
+
+        assertEquals(true, predicate.test(createRequest("/geoserver/def")));
+        assertEquals(true, predicate.test(createRequest("/geoserver/def/")));
+    }
+
+    /** Tests a good source (portal uuid) - one that exists. This time, using "/gggg" instead of "/geoserver". */
+    @Test
+    public void testGoodSource2() {
+        setupGnPortalPredicate(Arrays.asList("abc", "def", "ghi"));
+
+        var predicate = GnPortalPredicate.isGnPortalRequest("/gggg");
+
+        assertEquals(true, predicate.test(createRequest("/gggg/def")));
+        assertEquals(true, predicate.test(createRequest("/gggg/def/")));
+
+        assertEquals(false, predicate.test(createRequest("/geoserver/def")));
+        assertEquals(false, predicate.test(createRequest("/geoserver/def")));
+    }
+
+    /** Tests a bad source (portal uuid) - one that does NOT exists. */
+    @Test
+    public void testBadSource() {
+        setupGnPortalPredicate(Arrays.asList("abc", "def", "ghi"));
+
+        var predicate = GnPortalPredicate.isGnPortalRequest("/geoserver");
+
+        assertEquals(false, predicate.test(createRequest("/geoserver/zzz")));
+        assertEquals(false, predicate.test(createRequest("/geoserver/zzz/")));
+    }
+
+    public ServerRequest createRequest(String path) {
+        ServerRequest request = mock(ServerRequest.class);
+        when(request.path()).thenReturn(path);
+        return request;
+    }
+
+    /**
+     * This setups up a STATIC class (GnPortalPredicate). Watch for side effects!!!
+     *
+     * <p>TODO: make the class non-static.
+     *
+     * @param allSourceUUID list of the uuids to put in the mocked source reposition
+     */
+    public void setupGnPortalPredicate(List<String> allSourceUUID) {
+        var mockSourceRepository = mock(SourceRepository.class);
+        when(mockSourceRepository.findAll())
+                .thenReturn(allSourceUUID.stream()
+                        .map(x -> {
+                            var result = new Source();
+                            result.setUuid(x);
+                            return result;
+                        })
+                        .toList());
+
+        GnPortalPredicate.applicationContext = mock(ApplicationContext.class);
+        when(GnPortalPredicate.applicationContext.getBean(SourceRepository.class))
+                .thenReturn(mockSourceRepository);
+    }
+}


### PR DESCRIPTION
@fxprunayre was looking at changing some of the location of the GN5-proxy-to-GN4 (`cloud: gateway:  mvc` in `application.yml`).  One of the issues was dealing with the different GN4 portals (i.e. GN DB table `sources`).

This is a simple spring filter predicate that is aware of the defined Portals (subportals etc...).

```
  cloud:
    gateway:
      mvc:
         routes:
           - id: geonetwork_route
             uri: ${geonetwork.core.url}
             predicates:
               - isGnPortalRequest=/geonetwork
             filters:
               - addSimpleGn4SecurityHeader=gn5.to.gn4.trusted.json.auth
```

The interesting part is:

```
      predicates:
               - isGnPortalRequest=/geonetwork
```

The new predicate is `isGnPortalRequest` and the argument is the context path ("/geonetwork").
It will proxy requests like `"/geonetwork/srv/..."` and `"/geonetwork/<portal name>/..."` where `<portal name>` is the UUID of a `source` in the `sources` db table.

The underlying issue is that there are link the HTML created by GN4 that will not be correct if its in the "wrong" context path.  This helps with this problem, but doesn't fully solve it.


