### PR TITLE
Handle XSRF token through a fetch middleware

### DIFF
--- a/geonetwork-frontend/projects/glib/src/lib/config/config.loader.ts
+++ b/geonetwork-frontend/projects/glib/src/lib/config/config.loader.ts
@@ -1,6 +1,7 @@
 import {
   Configuration,
   DefaultConfig,
+  Middleware,
   SiteApi,
   UiApi,
   UiConfiguration,
@@ -54,10 +55,28 @@ export function buildGn4BaseUrl(baseUrl: string): string {
     : window.location.origin + gn4BaseUrl;
 }
 
+const xsrfMiddleware: Middleware = {
+  async pre(context) {
+    const xsrfToken = document.cookie
+      .split('; ')
+      .find(row => row.startsWith('XSRF-TOKEN='));
+    if (xsrfToken) {
+      context.init.headers = {
+        ...context.init.headers,
+        'X-XSRF-TOKEN': xsrfToken.split('=')[1],
+      };
+    }
+    return context;
+  },
+};
+
 export function loadAppConfig(environment: any) {
   console.log(environment);
   if (environment.baseUrl) {
-    appConfig.apiConfig = new Configuration({ basePath: environment.baseUrl });
+    appConfig.apiConfig = new Configuration({
+      basePath: environment.baseUrl,
+      middleware: [xsrfMiddleware],
+    });
     appConfig.api5Config = new Gn5Configuration({
       basePath: environment.baseUrlGn5Api,
     });

--- a/geonetwork-frontend/projects/glib/src/lib/editor/new-record-panel/new-record-panel.component.ts
+++ b/geonetwork-frontend/projects/glib/src/lib/editor/new-record-panel/new-record-panel.component.ts
@@ -286,8 +286,6 @@ export class NewRecordPanelComponent implements OnInit {
     this.recordsApi()
       .create(createRequest, {
         headers: {
-          // TODO: remove this? Header should be set in the gapi?
-          'X-XSRF-TOKEN': '17666fa5-607b-41d1-92ed-e1819c7da3b6',
           Accept: 'application/json', // Accept could be all?
           'Content-Type': 'application/json',
         },
@@ -650,12 +648,7 @@ export class NewRecordPanelComponent implements OnInit {
       };
 
       this.recordsApi()
-        .deleteRecord(deleteRecordRequest, {
-          headers: {
-            // TODO: remove this? Header should be set in the gapi?
-            'X-XSRF-TOKEN': '17666fa5-607b-41d1-92ed-e1819c7da3b6',
-          },
-        })
+        .deleteRecord(deleteRecordRequest)
         .then(
           response => {
             this.resetForm();


### PR DESCRIPTION
Instead of having hardcoded XSRF tokens when calling the GN4 API.

I haven't encountered the issue with the GN5 API but it might be worth it to do the same.

Note that this is required because the code generated using OpenAPI is not Angular code; otherwise the XSRF token handling would be done automatically by Angular.