### PR TITLE
Build / Fix warning due to duplicated gn-index-model dependency ref

### DIFF
--- a/src/modules/ogcapi-records/ogcapi-records-openapi-autogen/pom.xml
+++ b/src/modules/ogcapi-records/ogcapi-records-openapi-autogen/pom.xml
@@ -62,33 +62,22 @@
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
     </dependency>
-
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>33.3.1-jre</version>
     </dependency>
-
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <version>5.10.3</version>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>org.geonetwork</groupId>
-      <artifactId>gn-index-model</artifactId>
-      <version>${project.version}</version>
-      <scope>compile</scope>
-    </dependency>
-
   </dependencies>
 
   <build>


### PR DESCRIPTION
```
Some problems were encountered while building the effective model for org.geonetwork:gn-ogcapi-records-openapi-autogen:jar:5.0.0-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.geonetwork:gn-index-model:jar -> duplicate declaration of version ${project.version} @ line 85, column 17
```