### PR TITLE
Index page improvements and github action

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,49 @@
+name: Deploy MkDocs to GitHub Pages
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r ./docs/manual/requirements.txt
+
+      - name: Build site (config in docs/manual/, output to repo root ./site)
+        run: |
+          python -m mkdocs build -f docs/manual/mkdocs.yml -d ../../site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/manual/docs/index.md
+++ b/docs/manual/docs/index.md
@@ -5,7 +5,18 @@ hide:
 
 # GeoNetwork 5  {#toc}
 
-Welcome to GeoNetwork 5.  
+Welcome to GeoNetwork 5 documentation!  This documentation refers to the version 5, that is currently under development.
+
+## Looking for other versions?  
+- [GeoNetwork Latest Documentation](https://docs.geonetwork-opensource.org/4.4/)  
+- [GeoNetwork Stable Documentation](https://docs.geonetwork-opensource.org/4.2/)  
+
+
+## What’s new in GeoNetwork 5
+
+GeoNetwork 5 is the next big step in the project’s evolution. Its highlight is native support for the OGC API Records standard, bringing web-native, standards-based catalog services. Even though it’s still under development, you can already run it alongside GeoNetwork 4.4 and publish your existing catalogs through this new API, combining the stability of today with the possibilities of tomorrow.
+
+## Learn more
 
 <div class="grid cards" markdown>
 
@@ -13,7 +24,7 @@ Welcome to GeoNetwork 5.
 
     ---
 
-    Integrating GN5 and GN4 via the proxy gateway.
+    How to use GN5 and GN4 together via the proxy gateway.
 </div>
 
 <div class="grid cards" markdown>
@@ -22,7 +33,7 @@ Welcome to GeoNetwork 5.
 
     ---
 
-    OGCAPI-Records implementation.
+    Details of the implementation in GeoNetwork 5.
 </div>
 
 <div class="grid cards" markdown>
@@ -31,5 +42,16 @@ Welcome to GeoNetwork 5.
 
     ---
 
-    Developer docs.
+    Guides for contributing and extending GeoNetwork.
 </div>
+
+## Get Involved
+
+GeoNetwork is an open-source project, and its future depends on the community. There are several ways you can help shape GeoNetwork 5 and beyond:
+
+- Contribute code: Join the ongoing development and help build the next generation of metadata catalog services. A great first step is to join our [Developers Meeting](https://github.com/geonetwork/geonetwork/wiki/Meetings).
+- Sponsor developments: Support the project financially and help prioritize new features. Check out the [2025 Sponsorship Opportunities](https://github.com/geonetwork/core-geonetwork/wiki/GeoNetwork-2025-Sponsorship-Opportunities).
+
+
+Every contribution helps keep GeoNetwork strong, open, and innovative for the future.
+

--- a/docs/manual/mkdocs.yml
+++ b/docs/manual/mkdocs.yml
@@ -1,16 +1,16 @@
 # Project information
 site_name: GeoNetwork Opensource Microservices
 site_description: GeoNetwork Opensource Microservices.
-site_dir: target/html
-site_url: https://docs.geonetwork-opensource.org/
+site_url: https://geonetwork.github.io/geonetwork/
+docs_dir: .
 
 # Repository
 repo_name: geonetwork
 repo_url: https://github.com/geonetwork/geonetwork
-edit_uri: edit/main/docs/manual/docs
+edit_uri: edit/main/docs/manual
 
 # Copyright
-copyright: Copyright &copy; 2024 FAO-UN and others
+copyright: Copyright &copy; 2025 FAO-UN and others
 
 extra_css:
   - assets/stylesheets/extra.css
@@ -145,5 +145,19 @@ nav:
       - GN4-Integration/index.md
       - GN4-Integration/auth-json.md
       - GN4-Integration/auth-jwt.md
+    - 'OGC API Records':
+      - OGCAPI-Records/index.md
+      - OGCAPI-Records/config.md
+      - OGCAPI-Records/content-negotiation.md
+      - OGCAPI-Records/demo-server.md
+      - OGCAPI-Records/deploy.md
+      - OGCAPI-Records/spec-diff.md
+      - OGCAPI-Records/develop.md
+      - OGCAPI-Records/features.md
+    - 'Developer documentation':
+      - Developer/index.md
+      - Developer/formatters.md
+      - Developer/tech-security.md
+    
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-mkdocs-material>=9.5.3
-mkdocs-static-i18n>=1.0.5
-mkdocs-include-markdown-plugin
-mkdocs-exclude
-mike==2.0.0


### PR DESCRIPTION
# Add GitHub Action for manual publishing as github page

1) Added a github action to publish mkdocs documentation as github pages
2) Small homepage update, added latest content:
<img width="1353" height="855" alt="image" src="https://github.com/user-attachments/assets/4e09621b-3255-47e8-8202-7417971e6cf4" />
 
## Type of Change
Select one:
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring

## Approach
Also: 
- Adjusted edit_uri to edit/main/docs/manual for correct GitHub links.
- Removed duplicate requirements.txt from root

## How to Verify
1. Merge the PR and go to https://geonetwork.github.io/geonetwork/ 
2. :crossed_fingers: 

## Checklist
- [X] Code is formatted and linted
- [X] All tests pass locally and in CI
- [X] Tests updated (if applicable)
- [X] Documentation updated (if applicable)

