### PR TITLE
Fix issues on startup

### DIFF
--- a/config/application-ogcapi-records.yml
+++ b/config/application-ogcapi-records.yml
@@ -5,13 +5,6 @@ geonetwork:
       includeElasticJson: false
     ogcapi-property-mapping:
       fields:
-        - ogcProperty: spatialRepresentationType
-          elasticProperty: cl_spatialRepresentationType.key
-          indexRecordProperty: codelists.["cl_spatialRepresentationType"].[*].properties.["key"]
-          typeOverride: LIST_STRING
-          facetsConfig:
-            - facetName: spatialRepresentationType
-              facetType: TERM
         - ogcProperty: resourceType
           elasticProperty: resourceType
           indexRecordProperty: resourceType
@@ -36,30 +29,6 @@ geonetwork:
             - facetName: keywords
               facetType: TERM
               bucketCount: 50
-        - ogcProperty: updateFrequency
-          elasticProperty: cl_maintenanceAndUpdateFrequency.key
-          indexRecordProperty: codelists.["cl_maintenanceAndUpdateFrequency"].[*].properties.["key"]
-          typeOverride: SINGLE_STRING
-          isSortable: true
-          isQueryable: true
-          facetsConfig:
-            - facetName: updateFrequency
-              facetType: TERM
-              bucketCount: 50
-        - ogcProperty: creationYearForResource
-          elasticProperty: creationYearForResource
-          indexRecordProperty: resourceDateDetails.["creationYearForResource"].[0]
-          isSortable: true
-          facetsConfig:
-            - facetName: creationYearForResource
-              facetType: HISTOGRAM_FIXED_INTERVAL
-              numberBucketInterval: 5
-              bucketCount: 25
-              bucketSorting: VALUE
-            - facetName: creationYearForResource2
-              facetType: HISTOGRAM_FIXED_BUCKET_COUNT
-              bucketCount: 5
-              bucketSorting: VALUE
         - ogcProperty: linkProtocol
           elasticProperty: linkProtocol
           indexRecordProperty: linkProtocols
@@ -71,26 +40,6 @@ geonetwork:
                   filterEquationCql: linkProtocol = 'OGC:WFS'
                 - filterName: availableInViewService
                   filterEquationCql: linkProtocol = 'OGC:WMS'
-        - ogcProperty: createDate
-          elasticProperty: createDate
-          indexRecordProperty: createDate
-          isSortable: true
-          isQueryable: true
-          facetsConfig:
-            - facetName: createDate
-              facetType: HISTOGRAM_FIXED_INTERVAL
-              calendarIntervalUnit: MONTH
-              bucketCount: 25
-              bucketSorting: VALUE
-            - facetName: createDate2
-              facetType: HISTOGRAM_FIXED_BUCKET_COUNT
-              bucketCount: 5
-              bucketSorting: VALUE
-        - ogcProperty: resourceTitleObject
-          elasticProperty: resourceTitleObject.default
-          indexRecordProperty: resourceTitle.["default"]
-          isSortable: true
-          isQueryable: true
         - ogcProperty: resolutionScaleDenominator
           elasticProperty: resolutionScaleDenominator
           indexRecordProperty: resolutionScaleDenominator
@@ -106,22 +55,73 @@ geonetwork:
               facetType: HISTOGRAM_FIXED_BUCKET_COUNT
               bucketCount: 5
               bucketSorting: VALUE
-        - ogcProperty: orgForResource
-          elasticProperty: OrgForResourceObject.default
-          indexRecordProperty: orgForResourceByRole.["OrgForResourceObject"].[*].["default"]
-          facetsConfig:
-            - facetName: orgForResource
-              facetType: TERM
-              bucketCount: 50
-
-
+        ## Commented to avoid issue #116
+        ## You can uncomment following lines after metadata schema initialization and some example record creation
+        # - ogcProperty: spatialRepresentationType
+        #   elasticProperty: cl_spatialRepresentationType.key
+        #   indexRecordProperty: codelists.["cl_spatialRepresentationType"].[*].properties.["key"]
+        #   typeOverride: LIST_STRING
+        #   facetsConfig:
+        #     - facetName: spatialRepresentationType
+        #       facetType: TERM
+        # - ogcProperty: updateFrequency
+        #   elasticProperty: cl_maintenanceAndUpdateFrequency.key
+        #   indexRecordProperty: codelists.["cl_maintenanceAndUpdateFrequency"].[*].properties.["key"]
+        #   typeOverride: SINGLE_STRING
+        #   isSortable: true
+        #   isQueryable: true
+        #   facetsConfig:
+        #     - facetName: updateFrequency
+        #       facetType: TERM
+        #       bucketCount: 50
+        # - ogcProperty: creationYearForResource
+        #   elasticProperty: creationYearForResource
+        #   indexRecordProperty: resourceDateDetails.["creationYearForResource"].[0]
+        #   isSortable: true
+        #   facetsConfig:
+        #     - facetName: creationYearForResource
+        #       facetType: HISTOGRAM_FIXED_INTERVAL
+        #       numberBucketInterval: 5
+        #       bucketCount: 25
+        #       bucketSorting: VALUE
+        #     - facetName: creationYearForResource2
+        #       facetType: HISTOGRAM_FIXED_BUCKET_COUNT
+        #       bucketCount: 5
+        #       bucketSorting: VALUE
+        # - ogcProperty: createDate
+        #   elasticProperty: createDate
+        #   indexRecordProperty: createDate
+        #   isSortable: true
+        #   isQueryable: true
+        #   facetsConfig:
+        #     - facetName: createDate
+        #       facetType: HISTOGRAM_FIXED_INTERVAL
+        #       calendarIntervalUnit: MONTH
+        #       bucketCount: 25
+        #       bucketSorting: VALUE
+        #     - facetName: createDate2
+        #       facetType: HISTOGRAM_FIXED_BUCKET_COUNT
+        #       bucketCount: 5
+        #       bucketSorting: VALUE
+        # - ogcProperty: resourceTitleObject
+        #   elasticProperty: resourceTitleObject.default
+        #   indexRecordProperty: resourceTitle.["default"]
+        #   isSortable: true
+        #   isQueryable: true
+        # - ogcProperty: orgForResource
+        #   elasticProperty: OrgForResourceObject.default
+        #   indexRecordProperty: orgForResourceByRole.["OrgForResourceObject"].[*].["default"]
+        #   facetsConfig:
+        #     - facetName: orgForResource
+        #       facetType: TERM
+        #       bucketCount: 50
 
 
     links:
       base-path: /ogcapi-records
       # Where is GN5's ogcapi-records located?
       # should end in "/" and shouldn't have "//" in the path
-      ogcApiRecordsBaseUrl: ${GN5_BASE_URL:http:////localhost:7979/geonetwork}${geonetwork.openapi-records.links.base-path}/
+      ogcApiRecordsBaseUrl: ${GN5_BASE_URL:http:////localhost:7979/geonetwork}/${geonetwork.openapi-records.links.base-path}/
       # How to link to GN (can be either GN4 or GN5's GN4 proxy)
       # should end in "/" and shouldn't have "//" in the path
       gnBaseUrl: ${GN4_PROXY_BASE_URL:http:////localhost:7979/geonetwork}/

--- a/docker/docker-compose-base.yml
+++ b/docker/docker-compose-base.yml
@@ -33,6 +33,15 @@ x-geonetwork-environment:
     -Des.password=
     -Dgeonetwork.ESFeaturesProxy.targetUri=http://elasticsearch:9200/gn-features/{_}
 
+
+  GEONETWORK_DB_TYPE: postgres
+  GEONETWORK_DB_HOST: database
+  GEONETWORK_DB_PORT: ${GEONETWORK_DB_PORT}
+  GEONETWORK_DB_NAME: ${GEONETWORK_DB_NAME}
+  GEONETWORK_DB_USERNAME: ${GEONETWORK_DB_USERNAME}
+  GEONETWORK_DB_PASSWORD: ${GEONETWORK_DB_PASSWORD}
+  VIRTUAL_HOST: localhost
+
 x-service-geonetwork:
   &default-service-geonetwork
   image: geonetwork:4.4.7

--- a/src/modules/ogcapi-records/ogcapi-records-integration-tests/src/test/java/org/geonetwork/infrastructure/ElasticPgMvcBaseTest.java
+++ b/src/modules/ogcapi-records/ogcapi-records-integration-tests/src/test/java/org/geonetwork/infrastructure/ElasticPgMvcBaseTest.java
@@ -39,7 +39,7 @@ import org.testcontainers.utility.MountableFile;
 
 @SpringBootTest(classes = GeonetworkApplication.class)
 @AutoConfigureMockMvc
-@ActiveProfiles(value = {"test"})
+@ActiveProfiles(value = {"test", "integration-test"})
 @ContextConfiguration(initializers = ElasticPgMvcBaseTest.class)
 public class ElasticPgMvcBaseTest implements ApplicationContextInitializer<ConfigurableApplicationContext> {
 

--- a/src/modules/ogcapi-records/ogcapi-records-integration-tests/src/test/resources/application-integration-test.yml
+++ b/src/modules/ogcapi-records/ogcapi-records-integration-tests/src/test/resources/application-integration-test.yml
@@ -1,0 +1,115 @@
+geonetwork:
+  openapi-records:
+    ogcapi-records-json:
+      includeRawXML: false
+      includeElasticJson: false
+    ogcapi-property-mapping:
+      fields:
+        - ogcProperty: resourceType
+          elasticProperty: resourceType
+          indexRecordProperty: resourceType
+          isSortable: true
+          isQueryable: true
+          facetsConfig:
+            - facetName: resourceType
+              facetType: TERM
+        - ogcProperty: format
+          elasticProperty: format
+          indexRecordProperty: formats
+          addPropertyToOutput: false
+          facetsConfig:
+            - facetName: format
+              facetType: TERM
+              bucketCount: 50
+        - ogcProperty: keywords
+          elasticProperty: tag.langeng
+          indexRecordProperty: tag.[*].["default"]
+          addPropertyToOutput: false
+          facetsConfig:
+            - facetName: keywords
+              facetType: TERM
+              bucketCount: 50
+        - ogcProperty: linkProtocol
+          elasticProperty: linkProtocol
+          indexRecordProperty: linkProtocols
+          facetsConfig:
+            - facetName: availableInServices
+              facetType: FILTER
+              filters:
+                - filterName: availableInDownloadService
+                  filterEquationCql: linkProtocol = 'OGC:WFS'
+                - filterName: availableInViewService
+                  filterEquationCql: linkProtocol = 'OGC:WMS'
+        - ogcProperty: resolutionScaleDenominator
+          elasticProperty: resolutionScaleDenominator
+          indexRecordProperty: resolutionScaleDenominator
+          isSortable: true
+          isQueryable: true
+          facetsConfig:
+            - facetName: resolutionScaleDenominator
+              facetType: HISTOGRAM_FIXED_INTERVAL
+              numberBucketInterval: 100000
+              bucketCount: 25
+              bucketSorting: VALUE
+            - facetName: resolutionScaleDenominator2
+              facetType: HISTOGRAM_FIXED_BUCKET_COUNT
+              bucketCount: 5
+              bucketSorting: VALUE
+        - ogcProperty: spatialRepresentationType
+          elasticProperty: cl_spatialRepresentationType.key
+          indexRecordProperty: codelists.["cl_spatialRepresentationType"].[*].properties.["key"]
+          typeOverride: LIST_STRING
+          facetsConfig:
+            - facetName: spatialRepresentationType
+              facetType: TERM
+        - ogcProperty: updateFrequency
+          elasticProperty: cl_maintenanceAndUpdateFrequency.key
+          indexRecordProperty: codelists.["cl_maintenanceAndUpdateFrequency"].[*].properties.["key"]
+          typeOverride: SINGLE_STRING
+          isSortable: true
+          isQueryable: true
+          facetsConfig:
+            - facetName: updateFrequency
+              facetType: TERM
+              bucketCount: 50
+        - ogcProperty: creationYearForResource
+          elasticProperty: creationYearForResource
+          indexRecordProperty: resourceDateDetails.["creationYearForResource"].[0]
+          isSortable: true
+          facetsConfig:
+            - facetName: creationYearForResource
+              facetType: HISTOGRAM_FIXED_INTERVAL
+              numberBucketInterval: 5
+              bucketCount: 25
+              bucketSorting: VALUE
+            - facetName: creationYearForResource2
+              facetType: HISTOGRAM_FIXED_BUCKET_COUNT
+              bucketCount: 5
+              bucketSorting: VALUE
+        - ogcProperty: createDate
+          elasticProperty: createDate
+          indexRecordProperty: createDate
+          isSortable: true
+          isQueryable: true
+          facetsConfig:
+            - facetName: createDate
+              facetType: HISTOGRAM_FIXED_INTERVAL
+              calendarIntervalUnit: MONTH
+              bucketCount: 25
+              bucketSorting: VALUE
+            - facetName: createDate2
+              facetType: HISTOGRAM_FIXED_BUCKET_COUNT
+              bucketCount: 5
+              bucketSorting: VALUE
+        - ogcProperty: resourceTitleObject
+          elasticProperty: resourceTitleObject.default
+          indexRecordProperty: resourceTitle.["default"]
+          isSortable: true
+          isQueryable: true
+        - ogcProperty: orgForResource
+          elasticProperty: OrgForResourceObject.default
+          indexRecordProperty: orgForResourceByRole.["OrgForResourceObject"].[*].["default"]
+          facetsConfig:
+            - facetName: orgForResource
+              facetType: TERM
+              bucketCount: 50

--- a/src/shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/indexConvert/dynamic/ElasticTypingSystem.java
+++ b/src/shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/indexConvert/dynamic/ElasticTypingSystem.java
@@ -148,8 +148,13 @@ public class ElasticTypingSystem {
 
         // start off getting the first level property
         var pathPart = path.removeFirst();
-        PropertyVariant elasticProperty = (PropertyVariant)
-                this.elasticIndexInfo.mappings().properties().get(pathPart)._get();
+        var first = this.elasticIndexInfo.mappings().properties().get(pathPart);
+        if (first == null) {
+            throw new IllegalStateException("Mapping for top-level field '" + pathPart + "' not found in index '"
+                    + indexRecordName + "'. Available top-level fields: "
+                    + this.elasticIndexInfo.mappings().properties().keySet());
+        }
+        PropertyVariant elasticProperty = (PropertyVariant) first._get();
 
         while (!path.isEmpty()) {
             pathPart = path.removeFirst();


### PR DESCRIPTION
# Fix error on startup

## Description
When you start GN5, connecting it to an empty GN4 (then Elasticsearch initialized but before loading any metadata record), ElasticTypingSystem fails because of missing fields defined in apllication.yml. These fields are available only after metadata schema is initialized in GN4 and some example records are indexed.


## Type of Change
Select one:
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
Closes/updates # (optional): Closed #116 

## Approach
This short-time solution is to comment these fields in apllication.yml (related to facets initialization) as long as the fields become available.
Long term solution is to make facets configurable via DB config (milestone 2).

## How to Verify
1. Run with an empty docker composition docker-compose-dev

## Checklist
- [X] Code is formatted and linted
- [ ] All tests pass locally and in CI
- [X] Tests updated (if applicable)
- [X] Documentation updated (if applicable)


