### PR TITLE
GN5 Docker refactor and documentation improvements

### DIFF
--- a/config/application.yml
+++ b/config/application.yml
@@ -11,7 +11,7 @@
 
 geonetwork:
   url: ${GN5_BASE_URL:http://localhost:7979/geonetwork}
-  home: /srv
+  home: /home
   index:
     url: ${ELASTIC_URL:http://localhost:9200}
     indexPrefix: gn5-
@@ -94,12 +94,12 @@ spring:
 #              - Path=/srv/api/records/{uuid}/attachments/**
 #            filters:
 #              - RewritePath=/srv/api/records/(?<uuid>.+)/attachments(?<segment>.*), /api/records/$\{uuid}/attachments$\{segment}
-          - id: geonetwork_route
-            uri: ${geonetwork.4.url}
-            predicates:
-              - isGeoNetwork4Request=
-            filters:
-              - addSimpleGn4SecurityHeader=gn5.to.gn4.trusted.json.auth
+#          - id: geonetwork_route
+#            uri: ${geonetwork.4.url}
+#            predicates:
+#              - isGeoNetwork4Request=
+#            filters:
+#              - addSimpleGn4SecurityHeader=gn5.to.gn4.trusted.json.auth
   batch:
     jdbc:
       initialize-schema: always

--- a/docker/README.md
+++ b/docker/README.md
@@ -31,6 +31,56 @@ docker compose -f docker-compose-base.yml -f docker-compose-dev.yml up -d
 docker compose -f docker-compose-base.yml -f docker-compose-dev.yml down
 ```
 
+Access Elastic at http://localhost:9200/
+
+Access GN4 at http://localhost:8080/geonetwork
+
+Other Configurations
+--------------------
+
+
+### GN4 Proxied by GN5
+
+This will run GN4 configured to accept GN5 logins.  When you login to GN5 and then access GN4 (via GN5's proxy) you will be logged in.
+
+If you run this configuration, you can **only** login to GN4 via GN5 and GN4 will **not** have any login buttons.
+Ensure that your GN5 configuration is setup to proxy to GN4 (including authentication).
+
+```bash
+docker compose -f docker-compose-base.yml -f docker-compose-dev.yml -f  docker-compose-proxy.yml up -d
+```
+
+### Just GN4
+
+*(advanced only)*
+
+If you just want to quickly create a GN4 that will connect to an already running PostgreSQL and Elastic:
+
+```bash
+docker compose   -f  docker-compose-gn4-only.yml up -d
+```
+
+PostgreSQL should be running on the local (docker host) machine on port 5432, database `geonetwork`, username `geonetwork`, and password `geonetwork`.
+
+Elastic should be running on the local (docker host) machine on port 9200. 
+
+
+## Helpful Commands
+
+### Remove volumes
+ 
+This will remove the volumes associated with the containers.  This is useful to reset your postgresql and elastic databases.
+
+```bash
+docker compose -f docker-compose-base.yml -f docker-compose-dev.yml down --volumes 
+```
+
+### Connect to Postgresql via `psql`:
+
+```bash
+docker exec -it development-database-1  psql -h localhost -U geonetwork
+```
+
 ## 🚀 Full Stack Setup
 This composition includes also GeoNetwork 5:
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,22 +1,38 @@
 # 🐳 Docker Compose for GeoNetwork 5 Development & Testing
 This project provides Docker Compose configurations to simplify local development and testing of GeoNetwork 5. It helps set up all necessary services without dealing with infrastructure dependencies manually.
 
-> [!IMPORTANT]
-> These configurations are created for the sole purpose of testing GeoNetwork 5 locally. In the development setup Geonetwork 4 is accessible on port 8080, and this should be avoided in a production environment. For more details, please check [JWT Headers](https://github.com/geonetwork/geonetwork/blob/main/docs/manual/docs/GN4-Integration/index.md#setting-up-gn5-and-gn4).
+You will, typically, run GN5 from the command line:
+
+```bash
+cd src/apps/geonetwork
+mvn spring-boot:run
+```
+
+There are three typical setups:
+
+1. Main Development Setup (recommended for development).  This runs PostgreSQL, Elastic, and GeoNetwork 4.  GeoNetwork 4 runs independently of GN5 - you can access GN4 [directly](http://localhost:8080/geonetwork) and login normally.  PostgreSQL and Elastic are shared between GN4 and GN5.
+2. GN4 Proxied by GN5 (recommended for actual deployments).  This also runs PostgreSQL, Elastic, and GeoNetwork 4.  However, GN4 is proxied behind GN5 and you **must** (a) login to GN5 (b) access GN4 via GN5 (http://localhost:7979/geonetwork/svr).  You cannot logon directly to GN4.
+3. Just GN4 (recommended for testing and development).  In this case, you will need to run PostgreSQL and Elastic yourself.  This only runs GN4, and is useful to quickly "spin-up" GN4 to view/edit the settings/records (i.e. PostgreSQL and Elastic).
+
+Most people will want to use the first ("Main Development Setup").
 
 
-
-## ⚙️ Development Setup (docker-compose-dev.yml)
+ 
+## ⚙️ Main Development Setup (docker-compose-dev.yml)
 This composition includes:
 
+| Service       |Functionality| Port                                     |
+|:--------------|:-------------------------|:-----------------------------------------|
+| GeoNetwork 4  |GeoNetwork 4 "sidecar" for GN5 (used for harvesting etc.)| [8080](http://localhost:8080/geonetwork) |
+| database      |PostgreSQL — Database backend for GeoNetwork| 5432                                     |
+| elasticsearch |Elasticsearch — Search engine backend| [9200](http://localhost:9200)            |
 
-|Service|Functionality|Port|
-|:-----------|:-------------------------|:-----|
-|geonetwork4|GeoNetwork 4 "sidecar" for GN5 (used for harvesting etc.)|8080|
-|database|PostgreSQL — Database backend for GeoNetwork|5432|
-|elasticsearch|Elasticsearch — Search engine backend|9200|
 
 This setup is ideal for developers working on GN5 who need a quick and clean environment.
+
+Typically, you will run GeoNetwork 5 - locally - from the command line on port [7979](http://localhost:7979/geonetwork/home).
+
+This will not have any 
 
 ▶️ Start the stack
 From the /docker directory:
@@ -31,9 +47,19 @@ docker compose -f docker-compose-base.yml -f docker-compose-dev.yml up -d
 docker compose -f docker-compose-base.yml -f docker-compose-dev.yml down
 ```
 
+🚮 Clean up the stack
+
+This will delete the volumes associated with the container - deleting all data in PostgreSQL and Elastic.
+
+```bash
+docker compose -f docker-compose-base.yml -f docker-compose-dev.yml down --volumes
+```
+
 Access Elastic at http://localhost:9200/
 
 Access GN4 at http://localhost:8080/geonetwork
+
+When running GN5 locally (via the command line), it will likely be at http://localhost:7979/geonetwork/home
 
 Other Configurations
 --------------------
@@ -45,6 +71,10 @@ This will run GN4 configured to accept GN5 logins.  When you login to GN5 and th
 
 If you run this configuration, you can **only** login to GN4 via GN5 and GN4 will **not** have any login buttons.
 Ensure that your GN5 configuration is setup to proxy to GN4 (including authentication).
+
+> [!IMPORTANT]
+> These configurations are created for the sole purpose of testing GeoNetwork 5 locally. In the development setup Geonetwork 4 is accessible on port 8080, and this should be avoided in a production environment. For more details, please check [JWT Headers](https://github.com/geonetwork/geonetwork/blob/main/docs/manual/docs/GN4-Integration/index.md#setting-up-gn5-and-gn4).
+
 
 ```bash
 docker compose -f docker-compose-base.yml -f docker-compose-dev.yml -f  docker-compose-proxy.yml up -d
@@ -105,4 +135,17 @@ docker compose -f docker-compose-base.yml -f docker-compose-full.yml up -d
 ```bash
 docker compose -f docker-compose-base.yml -f docker-compose-full.yml down
 ```
+
+### ElasticSearch
+
+Here are some useful elastic search commands.
+
+| URL                                                                                                                                            | Meaning                                                 |
+|:-----------------------------------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------|
+| http://localhost:9200/gn-records/?pretty                                                                                                       | See the Elastic JSON Index Properties and Configuration |
+| [http://localhost:9200/gn-records/_search?pretty=true&q=*:&ast;&size=999](http://localhost:9200/gn-records/_search?pretty=true&q=*:*&size=999) | See first 999 records in the Index                      |
+| http://localhost:9200/gn-records/_search?pretty=true&q=uuid:c186ad88-a47f-4391-8fb5-a721e01a36a1                                               | Search for a record by UUID                             |
+| http://localhost:9200/_cluster/settings?include_defaults=true                                                                                  | Cluster Settings                                        |
+| http://localhost:9200/_cluster/health?pretty                                                                                                   | Cluster Health                                          |
+
 

--- a/docker/docker-application.yml
+++ b/docker/docker-application.yml
@@ -11,6 +11,9 @@
 #
 
 geonetwork:
+  4:
+    url: ${GN4_BASE_URL:http://localhost:8080/geonetwork}
+    path: /srv
   openapi-records:
     links:
       # Where is GN5's ogcapi-records located?
@@ -62,6 +65,7 @@ geonetwork:
   core:
     url: ${GN4_BASE_URL:http://localhost:8080/geonetwork}
   url: ${GN4_DOCKER_URL:http://localhost:8080/geonetwork}
+  home: /home
   index:
     url: ${ELASTIC_URL:http://localhost:9200}
     indexPrefix: gn5-
@@ -94,14 +98,14 @@ geonetwork:
 server:
   port: 7979
   servlet:
-    context-path: /
+    context-path: /geonetwork
   forward-headers-strategy: framework
 
 spring:
   application:
     name: GeoNetwork
   datasource:
-    url: jdbc:postgresql://database:5432/geonetwork
+    url: jdbc:postgresql://host.docker.internal:5432/geonetwork
     driverClassName: org.postgresql.Driver
     #    url: jdbc:h2:mem:gn5
     #    url: jdbc:h2:~/gn;AUTO_SERVER=TRUE
@@ -133,12 +137,12 @@ spring:
     gateway:
       mvc:
         routes:
-          - id: geonetwork_route
-            uri: ${geonetwork.url}
-            predicates:
-              - Path=/geonetwork/**
-            filters:
-              - addSimpleGn4SecurityHeader=gn5.to.gn4.trusted.json.auth
+        # - id: geonetwork_route
+        #   uri: ${geonetwork.url}
+        #   predicates:
+        #     - Path=/geonetwork/**
+        #   filters:
+        #     - addSimpleGn4SecurityHeader=gn5.to.gn4.trusted.json.auth
   batch:
     jdbc:
       initialize-schema: always

--- a/docker/docker-compose-base.yml
+++ b/docker/docker-compose-base.yml
@@ -131,8 +131,12 @@ services:
         - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
         - xpack.security.enabled=false
         - xpack.security.enrollment.enabled=false
+        - cluster.routing.allocation.disk.threshold_enabled=false
+
     volumes:
       - esdata:/usr/share/elasticsearch/data
+      - ./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro,Z
+
     ports:
       - ${ELASTICSEARCH_PORT:-9200}:9200
     networks:

--- a/docker/docker-compose-gn4-only.yml
+++ b/docker/docker-compose-gn4-only.yml
@@ -23,17 +23,16 @@ x-geonetwork-environment:  &default-geonetwork-environment
     -Dlogout.success.url=http://localhost:7979/geonetwork/srv/eng/catalog.search
     -DloginForm=http://localhost:7979/geonetwork/srv/eng/catalog.signin
     -DloginErrorForm=http://localhost:7979/geonetwork/srv/eng/catalog.signin?failure=true
-    -Des.host=elasticsearch
+    -Des.host=host.docker.internal
     -Des.protocol=http
     -Des.port=9200
-    -Des.url=http://elasticsearch:9200
+    -Des.url=http://host.docker.internal:9200
     -Des.username=
     -Des.password=
-    -Dgeonetwork.ESFeaturesProxy.targetUri=http://elasticsearch:9200/gn-features/{_}
-
+    -Dgeonetwork.ESFeaturesProxy.targetUri=http://host.docker.internal:9200/gn-features/{_}
 
   GEONETWORK_DB_TYPE: postgres
-  GEONETWORK_DB_HOST: database
+  GEONETWORK_DB_HOST: host.docker.internal
   GEONETWORK_DB_PORT: ${GEONETWORK_DB_PORT}
   GEONETWORK_DB_NAME: ${GEONETWORK_DB_NAME}
   GEONETWORK_DB_USERNAME: ${GEONETWORK_DB_USERNAME}
@@ -50,53 +49,23 @@ x-service-geonetwork: &default-service-geonetwork
   restart: always
   volumes:
     - geonetwork:/catalogue-data
-  depends_on:
-    database:
-      condition: service_healthy
+#  depends_on:
+#    database:
+#      condition: service_healthy
   networks:
     - gn-network
+  extra_hosts:
+    - "host.docker.internal:host-gateway"
+  ports:
+    - 8080:8080
 
-volumes:
-  geonetwork:
-    name: ${COMPOSE_PROJECT_NAME}_geonetwork
-  esdata:
-    name: ${COMPOSE_PROJECT_NAME}_esdata
-  pgdata:
-    name: ${COMPOSE_PROJECT_NAME}_pgdata
 
-networks:
-  gn-network:
-    driver: bridge
+
 services:
-  database:
-    image: postgres:16
-    environment:
-      POSTGRES_USER: ${GEONETWORK_DB_USERNAME}
-      POSTGRES_PASSWORD: ${GEONETWORK_DB_PASSWORD}
-      POSTGRES_DB: ${GEONETWORK_DB_NAME}
-    command: [ "postgres",
-               "-c", "log_statement=all",
-               "-c", "logging_collector=true",
-               "-c", "log_file_mode=0644",
-               "-c", "log_directory=/var/log/postgresql",
-               "-c", "log_filename=postgresql.log" ]
-    healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB']
-      interval: 5s
-      timeout: 5s
-      retries: 5
-    volumes:
-      - pgdata:/var/lib/postgresql/data
-      - ./docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
-    ports:
-      - ${GEONETWORK_DB_PORT:-5432}:5432
-    networks:
-      - gn-network
-
-  geonetwork4: &geonetwork4
+  geonetwork4:
     <<: *default-service-geonetwork
     environment:
-      << : *default-geonetwork-environment
+      <<: *default-geonetwork-environment
       HARVESTER_SCHEDULER_ENABLED: "true"
       HARVESTER_REFRESH_INTERVAL_MINUTES: 2
       JWTHEADERS_UserNameHeaderName: gn5.to.gn4.trusted.json.auth
@@ -110,31 +79,10 @@ services:
     expose:
       - "8080"
 
-  elasticsearch:
-    image: elasticsearch:8.14.3
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
-      nofile:
-        soft: 65536
-        hard: 65536
-    healthcheck:
-      test: "curl -s http://localhost:9200 >/dev/null || exit 1"
-      interval: 10s
-      timeout: 2s
-      retries: 10
-    environment:
-        - cluster.name=docker-cluster
-        - bootstrap.memory_lock=true
-        - discovery.type=single-node
-        - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-        - xpack.security.enabled=false
-        - xpack.security.enrollment.enabled=false
-    volumes:
-      - esdata:/usr/share/elasticsearch/data
-    ports:
-      - ${ELASTICSEARCH_PORT:-9200}:9200
-    networks:
-      - gn-network
+volumes:
+  geonetwork:
+    name: ${COMPOSE_PROJECT_NAME}_geonetwork
 
+networks:
+  gn-network:
+    driver: bridge

--- a/docker/docker-compose-proxy.yml
+++ b/docker/docker-compose-proxy.yml
@@ -1,0 +1,21 @@
+services:
+  geonetwork4:
+    environment:
+      GN_CONFIG_PROPERTIES: >-
+        -Dgeonetwork.dir=/catalogue-data
+        -Dgeonetwork.formatter.dir=/catalogue-data/data/formatter
+        -Dgeonetwork.schema.dir=/opt/geonetwork/WEB-INF/data/config/schema_plugins
+        -Dgeonetwork.indexConfig.dir=/opt/geonetwork/WEB-INF/data/config/index
+        -Dgeonetwork.schemapublication.dir=/opt/geonetwork/WEB-INF/data/resources/schemapublication
+        -Dgeonetwork.htmlcache.dir=/opt/geonetwork/WEB-INF/data/resources/htmlcache
+        -Dgeonetwork.security.type=gn5
+        -Dlogout.success.url=http://localhost:7979/geonetwork/srv/eng/catalog.search
+        -DloginForm=http://localhost:7979/geonetwork/srv/eng/catalog.signin
+        -DloginErrorForm=http://localhost:7979/geonetwork/srv/eng/catalog.signin?failure=true
+        -Des.host=elasticsearch
+        -Des.protocol=http
+        -Des.port=9200
+        -Des.url=http://elasticsearch:9200
+        -Des.username=
+        -Des.password=
+        -Dgeonetwork.ESFeaturesProxy.targetUri=http://elasticsearch:9200/gn-features/{_}

--- a/docker/elasticsearch.yml
+++ b/docker/elasticsearch.yml
@@ -1,0 +1,9 @@
+cluster.name: "docker-cluster"
+network.host: 0.0.0.0
+
+# disable the high watermark error
+cluster.routing.allocation.disk.threshold_enabled: false
+# don't have to do this, but this is helpful for elastic startup with existing data volumes
+cluster.routing.allocation.disk.watermark.high: 99.9%
+cluster.routing.allocation.disk.watermark.low: 99.9%
+cluster.routing.allocation.disk.watermark.flood_stage: 99.9%

--- a/docs/manual/docs/OGCAPI-Records/demo-server.md
+++ b/docs/manual/docs/OGCAPI-Records/demo-server.md
@@ -123,27 +123,27 @@ mvn spring-boot:run
 
 ##### Running the DEMO
 
-0. Go to [http://localhost:7979/v3/api-docs?f=json](http://localhost:7979/v3/api-docs?f=json) to see the [OpenAPI](https://www.openapis.org/) (swagger) documentation.
-1. Go to [http://localhost:7979/ogcapi-records/?f=json](http://localhost:7979/ogcapi-records/?f=json)
+0. Go to [http://localhost:7979/geonetwork/v3/api-docs?f=json](http://localhost:7979/geonetwork/v3/api-docs?f=json) to see the [OpenAPI](https://www.openapis.org/) (swagger) documentation.
+1. Go to [http://localhost:7979/geonetwork/ogcapi-records/?f=json](http://localhost:7979/geonetwork/ogcapi-records/?f=json)
     * This is the OGCAPI-Records Landing Page
     * The title should be "GeoCat Demo OGCIAPI Server"
     * Notice that it has an extra `catalogInfo` which contains information taken from `main.xml`
-2. Go to [http://localhost:7979/ogcapi-records/collections?f=json](http://localhost:7979/ogcapi-records/collections?f=json)
+2. Go to [http://localhost:7979/geonetwork/ogcapi-records/collections?f=json](http://localhost:7979/geonetwork/ogcapi-records/collections?f=json)
     * This is the OGCAPI-Records Collections ("Catalogs") page
     * There should be two collections - "GeoCat Demo OGCIAPI Server" and "GeoCat Demo OGCIAPI sub-portal"
     * Notice that the title (and contact) information is coming from the linked metadata records (`main.xml` and `subportal.xml`)
-3. Go to [http://localhost:7979/ogcapi-records/collections/subportal?f=json](http://localhost:7979/ogcapi-records/collections/subportal?f=json)
+3. Go to [http://localhost:7979/geonetwork/ogcapi-records/collections/subportal?f=json](http://localhost:7979/geonetwork/ogcapi-records/collections/subportal?f=json)
     * This is the OGCAPI-Records Collection ("Catalog") page for the sub-portal collection
     * The metadata about this is coming from the attached `subportal.xml` record
-4. Go to [http://localhost:7979/ogcapi-records/collections/subportal/queryables?f=json](http://localhost:7979/ogcapi-records/collections/subportal/queryables?f=json)
+4. Go to [http://localhost:7979/geonetwork/ogcapi-records/collections/subportal/queryables?f=json](http://localhost:7979/geonetwork/ogcapi-records/collections/subportal/queryables?f=json)
     * This is the OGCAPI-Records Queryables page for the sub-portal collection
     * This are all the "extra" ways you can query the collection
     * Advanced users can see how this is configured [in queryables.json](https://github.com/geonetwork/geonetwork/pull/74/files#diff-9185e89c379fe0a8287daf7c7b09389dcf35bb8667e885fc607326eb48dd660a).
-5. Go to [http://localhost:7979/ogcapi-records/collections/subportal/items?f=json](http://localhost:7979/ogcapi-records/collections/subportal/items?f=json)
+5. Go to [http://localhost:7979/geonetwork/ogcapi-records/collections/subportal/items?f=json](http://localhost:7979/geonetwork/ogcapi-records/collections/subportal/items?f=json)
     * This is the OGCAPI-Records Items page for the sub-portal collection
     * This returns a [GeoJSON](https://geojson.org/) feature collection JSON document
     * Since we haven't put a filter on the sub-portal, all 7 metadata records in the GN4 catalog will be shown
-6. Go to [http://localhost:7979/ogcapi-records/collections/subportal/items/da165110-88fd-11da-a88f-000d939bc5d8?f=json](http://localhost:7979/ogcapi-records/collections/subportal/items/da165110-88fd-11da-a88f-000d939bc5d8?f=json)
+6. Go to [http://localhost:7979/geonetwork/ogcapi-records/collections/subportal/items/da165110-88fd-11da-a88f-000d939bc5d8?f=json](http://localhost:7979/geonetwork/ogcapi-records/collections/subportal/items/da165110-88fd-11da-a88f-000d939bc5d8?f=json)
     * This is the OGCAPI-Records Items page for single record in the sub-portal collection
     * This is the JSON representation of the ISO19193 record (in the format specified by the OGCAPI-Records specification and in GeoJSON format)
     * It also contains the underlying record, in XML, in the the `metadataRecordText` property
@@ -152,14 +152,14 @@ mvn spring-boot:run
 
 Here are some queries you can run (see the [queryables](https://github.com/geonetwork/geonetwork/pull/74/files#diff-9185e89c379fe0a8287daf7c7b09389dcf35bb8667e885fc607326eb48dd660a)):
 
-* Find `contacts` that contain "jody" [http://localhost:7979/ogcapi-records/collections/subportal/items?contacts=jody&f=json](http://localhost:7979/ogcapi-records/collections/subportal/items?contacts=jody&f=json)
-    * or [jeroen](http://localhost:7979/ogcapi-records/collections/subportal/items?contacts=jeroen&f=json)
-    * or by area code [250](http://localhost:7979/ogcapi-records/collections/subportal/items?contacts=250&f=json)
-    * or by city [victoria](http://localhost:7979/ogcapi-records/collections/subportal/items?contacts=victoria&f=json)
-* Find by `id` [http://localhost:7979/ogcapi-records/collections/subportal/items?id=9bac358b-11ec-4293-aeef-5a077b778412&f=json](http://localhost:7979/ogcapi-records/collections/subportal/items?id=9bac358b-11ec-4293-aeef-5a077b778412&f=json)
-* Find by `organization` [http://localhost:7979/ogcapi-records/collections/subportal/items?organization=geocat&f=json](http://localhost:7979/ogcapi-records/collections/subportal/items?organization=geocat&f=json)
-* Find by `keyword` [http://localhost:7979/ogcapi-records/collections/subportal/items?keywords=africa&f=json](http://localhost:7979/ogcapi-records/collections/subportal/items?keywords=africa&f=json)
-* Find records created in 2008 [http://localhost:7979/ogcapi-records/collections/subportal/items?created=2007-01-01/2007-12-31&f=json](http://localhost:7979/ogcapi-records/collections/subportal/items?created=2007-01-01/2007-12-31&f=json)
+* Find `contacts` that contain "jody" [http://localhost:7979/geonetwork/ogcapi-records/collections/subportal/items?contacts=jody&f=json](http://localhost:7979/geonetwork/ogcapi-records/collections/subportal/items?contacts=jody&f=json)
+    * or [jeroen](http://localhost:7979/geonetwork/ogcapi-records/collections/subportal/items?contacts=jeroen&f=json)
+    * or by area code [250](http://localhost:7979/geonetwork/ogcapi-records/collections/subportal/items?contacts=250&f=json)
+    * or by city [victoria](http://localhost:7979/geonetwork/ogcapi-records/collections/subportal/items?contacts=victoria&f=json)
+* Find by `id` [http://localhost:7979/geonetwork/ogcapi-records/collections/subportal/items?id=9bac358b-11ec-4293-aeef-5a077b778412&f=json](http://localhost:7979/geonetwork/ogcapi-records/collections/subportal/items?id=9bac358b-11ec-4293-aeef-5a077b778412&f=json)
+* Find by `organization` [http://localhost:7979/geonetwork/ogcapi-records/collections/subportal/items?organization=geocat&f=json](http://localhost:7979/geonetwork/ogcapi-records/collections/subportal/items?organization=geocat&f=json)
+* Find by `keyword` [http://localhost:7979/geonetwork/ogcapi-records/collections/subportal/items?keywords=africa&f=json](http://localhost:7979/geonetwork/ogcapi-records/collections/subportal/items?keywords=africa&f=json)
+* Find records created in 2008 [http://localhost:7979/geonetwork/ogcapi-records/collections/subportal/items?created=2007-01-01/2007-12-31&f=json](http://localhost:7979/geonetwork/ogcapi-records/collections/subportal/items?created=2007-01-01/2007-12-31&f=json)
 
 NOTE: See the [OGCAPI-Records Specification](https://ogcapi.ogc.org/records/#:~:text=OGC%20API%20%2D%20Records%20is%20a,resources%20(metadata)%20are%20exposed.) for more info on querying.
 

--- a/docs/manual/docs/OGCAPI-Records/features.md
+++ b/docs/manual/docs/OGCAPI-Records/features.md
@@ -10,6 +10,6 @@ The GeoNetwork 5 OGCAPI-Records module has several features that aren't standard
     * There will be a `metadataRecordText` property with the text of the metadata record
     * There will be a `geoNetworkElasticIndexRecord` property with the underlying Elastic Index Record for that metadata record.
 4. When doing a text search ("`q`"), you can add `<queryable Property Name>:<search value>` and it will convert that into a queryables search
-    * For example, `http://localhost:7979/ogcapi-records/collections/subportal/items?q=portal%20contacts:geocat` is equivalent to  `http://localhost:7979/ogcapi-records/collections/subportal/items?q=portal&contacts=geocat`
+    * For example, `http://localhost:7979/geonetwork/ogcapi-records/collections/subportal/items?q=portal%20contacts:geocat` is equivalent to  `http://localhost:7979/geonetwork/ogcapi-records/collections/subportal/items?q=portal&contacts=geocat`
     * This was done because most OGCAPI-Records clients do **not** support queryables. 
 5. Security.  The logged in user can only see certain records (see `ElasticWithUserPermissions.java`).

--- a/src/apps/geonetwork/src/main/java/org/geonetwork/config/MvcConfiguration.java
+++ b/src/apps/geonetwork/src/main/java/org/geonetwork/config/MvcConfiguration.java
@@ -23,7 +23,6 @@ public class MvcConfiguration implements WebMvcConfigurer {
     public void addViewControllers(ViewControllerRegistry registry) {
         String viewName = homeUrl.equals("/") ? "home" : "redirect:" + homeUrl;
         registry.addViewController("/").setViewName(viewName);
-        registry.addViewController("/home").setViewName("home");
         registry.addViewController("/signin").setViewName("signin");
     }
 }

--- a/src/apps/geonetwork/src/main/java/org/geonetwork/controllers/HomeController.java
+++ b/src/apps/geonetwork/src/main/java/org/geonetwork/controllers/HomeController.java
@@ -1,0 +1,23 @@
+package org.geonetwork.controllers;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+/**
+ * controller for `/home`.  This allows for run-time variables to be injected into the view.
+ */
+@Controller
+public class HomeController {
+
+  @Value("${geonetwork.4.url:'/geonetwork'}")
+  public String gn4URL;
+
+  @GetMapping("/home")
+  public String home(Model model) {
+    model.addAttribute("gn4_url",gn4URL);
+    return "home";
+  }
+
+}

--- a/src/apps/geonetwork/src/main/java/org/geonetwork/controllers/HomeController.java
+++ b/src/apps/geonetwork/src/main/java/org/geonetwork/controllers/HomeController.java
@@ -1,3 +1,8 @@
+/*
+ * (c) 2003 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license,
+ * available at the root application directory.
+ */
 package org.geonetwork.controllers;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -5,19 +10,16 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
-/**
- * controller for `/home`.  This allows for run-time variables to be injected into the view.
- */
+/** controller for `/home`. This allows for run-time variables to be injected into the view. */
 @Controller
 public class HomeController {
 
-  @Value("${geonetwork.4.url:'/geonetwork'}")
-  public String gn4URL;
+    @Value("${geonetwork.4.url:'/geonetwork'}")
+    public String gn4URL;
 
-  @GetMapping("/home")
-  public String home(Model model) {
-    model.addAttribute("gn4_url",gn4URL);
-    return "home";
-  }
-
+    @GetMapping("/home")
+    public String home(Model model) {
+        model.addAttribute("gn4_url", gn4URL);
+        return "home";
+    }
 }

--- a/src/apps/geonetwork/src/main/resources/templates/home.html
+++ b/src/apps/geonetwork/src/main/resources/templates/home.html
@@ -61,7 +61,7 @@
   <p>Your gateway to all your data, maps, services and more!</p>
 
   <div class="container unauthenticated">
-    <a th:href="@{/srv}">GeoNetwork 4</a>
+    <a th:href="${gn4_url}">GeoNetwork 4</a>
     <br/>
     <br/>
     <a th:href="@{/ogcapi-records}">OGC API Records</a>


### PR DESCRIPTION
# Docker refactor and documentation improvements

## Description
Based on work started here https://github.com/geonetwork/geonetwork/pull/119 by @davidblasby 

1. Fix documentation for changes introduced by https://github.com/geonetwork/geonetwork/pull/82
2. change PG from v17 to v16.  This is because there are some v17 compatibility issues with things like v16 psql.
3. default is now "normal" GN4 (instead of the proxied).  Use `... -f docker-compose-proxy.yml ...` and you'll get the old behaviour.  I think being able to log on to GN4 with admin/admin (by default) makes life a lot easier.
4. added an independent `docker-compose-gn4-only.yml` so you can quickly run GN4 without spinning up the included PG and Elastic - useful for people with their own data already setup
5. added some more to the README


## Type of Change
Select one:
- [ ] Bug fix
- [ ] New feature
- [X] Documentation update
- [X] Refactoring

## Approach
[Check here](https://github.com/geonetwork/geonetwork/pull/119)


## Checklist
- [ ] Code is formatted and linted
- [ ] All tests pass locally and in CI
- [ ] Tests updated (if applicable)
- [ ] Documentation updated (if applicable)

