### PR TITLE
Fix for the XmlMapperConfig bean creation at startup

### DIFF
--- a/src/apps/geonetwork/src/main/java/org/geonetwork/configuration/XmlMapperConfig.java
+++ b/src/apps/geonetwork/src/main/java/org/geonetwork/configuration/XmlMapperConfig.java
@@ -1,0 +1,19 @@
+/*
+ * SPDX-FileCopyrightText: 2001 FAO-UN and others <geonetwork@osgeo.org>
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+package org.geonetwork.configuration;
+
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class XmlMapperConfig {
+
+    @Bean
+    public XmlMapper xmlMapper() {
+        return new XmlMapper();
+    }
+}


### PR DESCRIPTION
Suggested fix for startup error . 

```
***************************
APPLICATION FAILED TO START
***************************

Description:

Field xmlMapper in org.geonetwork.ogcapi.ctrlreturntypes.OgcApiRecordsCollectionsResponseFormatter required a bean of type 'com.fasterxml.jackson.dataformat.xml.XmlMapper' that could not be found.

The injection point has the following annotations:
 ```