### PR TITLE
Fix Geonetwork main app

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,7 @@ Architecture experiment for GeoNetwork 5 development setting up clean Spring Boo
 
 To run GeoNetwork 5 in dev mode, you first need to run GeoNetwork 4 with shared data base:
 
-1. **Run GeoNetwork 4.4** in your favorite way ( [see GeoNetwork 4 documentation](https://github.com/geonetwork/core-geonetwork/tree/main/software_development#quickstart)) and remind the options to connect to the database and Elasticsearch.
-   
-   Example Development Environment (with Docker Compose):
-   
-   ```bash
-   cd docker
-   docker compose -f docker-compose-base.yml -f docker-compose-dev.yml up -d
-   ```
-   
-   Access GN4: http://localhost:8080/geonetwork/ (login `admin`/`admin`)
+1. **Run GeoNetwork 4.4** in your favorite way ( [see GeoNetwork 4 documentation](https://github.com/geonetwork/core-geonetwork/tree/main/software_development#quickstart)) or use some of the docker options available [here](./docker/README.md).
    
 
 2. **Configure GeoNetwork 5** search application by editing the file `config/application.yml`.

--- a/src/apps/geonetwork/pom.xml
+++ b/src/apps/geonetwork/pom.xml
@@ -19,6 +19,11 @@
   <dependencies>
     <dependency>
       <groupId>org.geonetwork</groupId>
+      <artifactId>gn-generic-app</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.geonetwork</groupId>
       <artifactId>gn-ogcapi-records-implementation</artifactId>
       <version>${project.version}</version>
     </dependency>


### PR DESCRIPTION
# Fix Geonetwork main app

## Description
On startup [geonetwork main app](https://github.com/geonetwork/geonetwork/tree/dev/src/apps/geonetwork) returns this error:

```
***************************
APPLICATION FAILED TO START
***************************

Description:

Field xmlMapper in org.geonetwork.ogcapi.ctrlreturntypes.OgcApiRecordsCollectionsResponseFormatter required a bean of type 'com.fasterxml.jackson.dataformat.xml.XmlMapper' that could not be found.

The injection point has the following annotations:
    - @org.springframework.beans.factory.annotation.Autowired(required=true)


Action:

Consider defining a bean of type 'com.fasterxml.jackson.dataformat.xml.XmlMapper' in your configuration.
```

This is caused by geonetwork main app not being configured with right dependencies. Every app must contain gn-generic-app dependency as follow:

```
    <dependency>
      <groupId>org.geonetwork</groupId>
      <artifactId>gn-generic-app</artifactId>
      <version>${project.version}</version>
    </dependency>
```

This PR also fixes some sentences in the main README that are not updated with the latest developments.

## Type of Change
Select one:
- [X] Bug fix
- [ ] New feature
- [X] Documentation update
- [ ] Refactoring


## How to Verify
1. `mvn spring-boot:run` this https://github.com/geonetwork/geonetwork/tree/dev/src/apps/geonetwork 


## Checklist
- [X] Code is formatted and linted
- [X] All tests pass locally and in CI
- [X] Tests updated (if applicable)
- [X] Documentation updated (if applicable)

