### PR TITLE
API / Browse OpenAPI doc using scalar

### DIFF
--- a/config/application.yml
+++ b/config/application.yml
@@ -102,8 +102,22 @@ management:
         include: "*"
 
 springdoc:
+  api-docs:
+    default-produces-media-type: application/json
   swagger-ui:
     path: /swagger-ui
+
+scalar:
+  enabled: true
+  path: /doc/api/discover
+  sources:
+    - url: ../../v3/api-docs
+      title: GeoNetwork 5 API
+      slug: gn5
+      isDefault: true
+    - url: ../../srv/api/doc
+      title: GeoNetwork 4 API
+      slug: gn4
 
 
 debug: false

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,8 @@
   <properties>
     <java.version>21</java.version>
     <spring-cloud.version>2025.0.1</spring-cloud.version>
+    <springdoc.version>2.8.16</springdoc.version>
+    <swagger.version>2.2.45</swagger.version>
     <es.version>8.14.1</es.version>
     <jackson.version>2.17.3</jackson.version>
     <spotless.version>2.43.0</spotless.version>
@@ -163,12 +165,27 @@
       <dependency>
         <groupId>org.springdoc</groupId>
         <artifactId>springdoc-openapi-starter-common</artifactId>
-        <version>2.8.4</version>
+        <version>${springdoc.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springdoc</groupId>
         <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-        <version>2.8.4</version>
+        <version>${springdoc.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springdoc</groupId>
+        <artifactId>springdoc-openapi-starter-webmvc-scalar</artifactId>
+        <version>${springdoc.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.swagger.core.v3</groupId>
+        <artifactId>swagger-annotations-jakarta</artifactId>
+        <version>${swagger.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.swagger.core.v3</groupId>
+        <artifactId>swagger-annotations</artifactId>
+        <version>${swagger.version}</version>
       </dependency>
       <dependency>
         <groupId>org.thymeleaf.extras</groupId>

--- a/src/apps/generic-geonetwork5/pom.xml
+++ b/src/apps/generic-geonetwork5/pom.xml
@@ -80,6 +80,10 @@
       <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-starter-webmvc-scalar</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.thymeleaf.extras</groupId>
       <artifactId>thymeleaf-extras-springsecurity6</artifactId>
     </dependency>

--- a/src/apps/generic-geonetwork5/src/main/java/org/geonetwork/config/WebSecurityConfiguration.java
+++ b/src/apps/generic-geonetwork5/src/main/java/org/geonetwork/config/WebSecurityConfiguration.java
@@ -33,10 +33,16 @@ public class WebSecurityConfiguration {
             @Value("${geonetwork.home: '/'}") String homeUrl)
             throws Exception {
         http.csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(requests -> requests.requestMatchers("/", "/home", "/signin", "/test")
-                        .permitAll())
-                .authorizeHttpRequests(authz -> authz.requestMatchers(
-                                "**", "/ogcapi-records/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html")
+                .authorizeHttpRequests(requests -> requests.requestMatchers(
+                                "/",
+                                "/home",
+                                "/signin",
+                                "/test",
+                                "**",
+                                "/ogcapi-records/**",
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html")
                         .permitAll()
                         .anyRequest()
                         .authenticated())

--- a/src/apps/geonetwork/pom.xml
+++ b/src/apps/geonetwork/pom.xml
@@ -138,6 +138,10 @@
       <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-starter-webmvc-scalar</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.thymeleaf.extras</groupId>
       <artifactId>thymeleaf-extras-springsecurity6</artifactId>
     </dependency>

--- a/src/modules/ogcapi-records/ogcapi-records-implementation/src/main/java/org/geonetwork/ogcapi/configuration/TrivialHtmlMessageWriter.java
+++ b/src/modules/ogcapi-records/ogcapi-records-implementation/src/main/java/org/geonetwork/ogcapi/configuration/TrivialHtmlMessageWriter.java
@@ -8,10 +8,12 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpOutputMessage;
@@ -20,9 +22,14 @@ import org.springframework.http.converter.AbstractGenericHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.converter.HttpMessageNotWritableException;
 import org.springframework.lang.Nullable;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 @Configuration
-public class TrivialHtmlMessageWriter extends AbstractGenericHttpMessageConverter {
+public class TrivialHtmlMessageWriter extends AbstractGenericHttpMessageConverter<Object> {
+
+    @Value("${geonetwork.openapi-records.links.base-path:/ogcapi-records}")
+    private String ogcApiRecordsBasePath;
 
     TrivialHtmlMessageWriter() {
         this(MediaType.TEXT_HTML);
@@ -30,6 +37,20 @@ public class TrivialHtmlMessageWriter extends AbstractGenericHttpMessageConverte
 
     TrivialHtmlMessageWriter(MediaType supportedMediaType) {
         super(supportedMediaType);
+    }
+
+    @Override
+    public boolean canWrite(@Nullable Type type, Class<?> clazz, @Nullable MediaType mediaType) {
+        if (!super.canWrite(type, clazz, mediaType)) {
+            return false;
+        }
+        var attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        if (attributes != null) {
+            HttpServletRequest request = attributes.getRequest();
+            String path = request.getRequestURI();
+            return path.contains(ogcApiRecordsBasePath);
+        }
+        return false;
     }
 
     @Override

--- a/src/modules/pom.xml
+++ b/src/modules/pom.xml
@@ -28,8 +28,4 @@
     <module>formatting</module>
     <module>thesaurus</module>
   </modules>
-
-  <properties>
-    <swagger.version>2.1.2</swagger.version>
-  </properties>
 </project>


### PR DESCRIPTION
Alternative to swagger-ui:
* allows to browse both GN4 and GN5 OpenAPIs in the same interface
* search feature
* more options/themes for customization

<img width="571" height="365" alt="image" src="https://github.com/user-attachments/assets/1d92aeb7-13c2-4ccc-b7d9-f524c66e7ba8" />


<img width="837" height="440" alt="image" src="https://github.com/user-attachments/assets/78483d41-535e-4530-8730-1abad60b7a3b" />



<img width="1078" height="776" alt="image" src="https://github.com/user-attachments/assets/4959f25e-d8aa-4a4f-8508-800ccd27a802" />



Java documentation
https://scalar.com/products/api-references/integrations/java

Scalar
https://github.com/scalar/scalar



To be tested and see if more relevant to use it as default OpenAPI browser.

Related to:
* https://github.com/geonetwork/core-geonetwork/pull/9200


## Type of Change
Select one:
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
Closes/updates # (optional):

## Approach
<!-- Outline your solution and any key decisions. Bullet points are fine. -->

## How to Verify

http://localhost:8080/geonetwork/doc/api/discover

## Checklist
- [ ] Code is formatted and linted
- [ ] All tests pass locally and in CI
- [ ] Tests updated (if applicable)
- [ ] Documentation updated (if applicable)

<!--
Optional: add any extra notes, credits (e.g., "Funded by ..."), or dependencies.
-->
