### PR TITLE
Database / Liquibase

### DIFF
--- a/config/application.yml
+++ b/config/application.yml
@@ -59,6 +59,9 @@ spring:
     driverClassName: org.postgresql.Driver
     username: geonetwork
     password: geonetwork
+  liquibase:
+    enabled: true
+    change-log: classpath:/db/changelog.xml
   jpa:
     open-in-view: false
     database-platform: org.hibernate.dialect.PostgreSQLDialect

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,8 @@
     <spring-cloud.version>2025.0.1</spring-cloud.version>
     <es.version>8.14.1</es.version>
     <jackson.version>2.17.3</jackson.version>
+    <liquibase.version>4.29.2</liquibase.version>
+    <gn4.version>4.4.10-SNAPSHOT</gn4.version>
     <spotless.version>2.43.0</spotless.version>
     <lombok.version>1.18.34</lombok.version>
     <errorProne.version>2.18.0</errorProne.version>
@@ -119,9 +121,20 @@
         <version>42.7.3</version>
       </dependency>
       <dependency>
-        <groupId>com.h2database</groupId>
-        <artifactId>h2</artifactId>
-        <version>2.2.224</version>
+        <groupId>org.liquibase</groupId>
+        <artifactId>liquibase-core</artifactId>
+        <version>${liquibase.version}</version>
+        <exclusions>
+          <exclusion>
+            <artifactId>liquibase-commercial</artifactId>
+            <groupId>org.liquibase</groupId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.geonetwork-opensource</groupId>
+        <artifactId>gn-database</artifactId>
+        <version>${gn4.version}</version>
       </dependency>
       <dependency>
         <groupId>co.elastic.clients</groupId>
@@ -151,7 +164,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>1.3.2</version>
+        <version>2.16.1</version>
       </dependency>
       <dependency>
         <groupId>org.projectlombok</groupId>

--- a/src/modules/geonetwork4/src/main/java/org/geonetwork/gn4/security/JwtSigning.java
+++ b/src/modules/geonetwork4/src/main/java/org/geonetwork/gn4/security/JwtSigning.java
@@ -11,6 +11,7 @@ import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyFactory;
 import java.security.PrivateKey;
 import java.security.PublicKey;
@@ -44,7 +45,7 @@ public class JwtSigning {
     public static PrivateKey getPrivateKey(String url) throws Exception {
         String privateKeyBase64;
         try (var stream = new URI(url).toURL().openStream()) {
-            privateKeyBase64 = IOUtils.toString(stream);
+            privateKeyBase64 = IOUtils.toString(stream, StandardCharsets.UTF_8);
         }
         if (privateKeyBase64.startsWith("-----BEGIN PRIVATE KEY-----")) {
             privateKeyBase64 = privateKeyBase64.replace("-----BEGIN PRIVATE KEY-----", "");

--- a/src/modules/indexing/src/test/java/org/geonetwork/indexing/IndexingServiceTest.java
+++ b/src/modules/indexing/src/test/java/org/geonetwork/indexing/IndexingServiceTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import co.elastic.clients.elasticsearch.core.ExistsRequest;
 import co.elastic.clients.transport.endpoints.BooleanResponse;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.TimeZone;
 import java.util.concurrent.Future;
@@ -54,7 +55,8 @@ class IndexingServiceTest extends ElasticsearchBasedIntegrationTest {
         String fileBaseName = String.format("samples/%s", file);
         // String xml = Files.readString(Path.of(new ClassPathResource(fileBaseName +
         // ".xml").getURI()));
-        String xml = IOUtils.toString(new ClassPathResource(fileBaseName + ".xml").getInputStream());
+        String xml =
+                IOUtils.toString(new ClassPathResource(fileBaseName + ".xml").getInputStream(), StandardCharsets.UTF_8);
 
         Metadata dbRecord = Metadata.builder()
                 .uuid(fileBaseName)

--- a/src/modules/indexing/src/test/java/org/geonetwork/indexing/IndexingStandardsTest.java
+++ b/src/modules/indexing/src/test/java/org/geonetwork/indexing/IndexingStandardsTest.java
@@ -8,6 +8,7 @@ package org.geonetwork.indexing;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.TimeZone;
 import org.apache.commons.io.IOUtils;
@@ -52,12 +53,14 @@ class IndexingStandardsTest {
         // String xml = Files.readString(Path.of(new ClassPathResource(fileBaseName +
         // ".xml").getURI()));
 
-        String xml = IOUtils.toString(new ClassPathResource(fileBaseName + ".xml").getInputStream());
+        String xml =
+                IOUtils.toString(new ClassPathResource(fileBaseName + ".xml").getInputStream(), StandardCharsets.UTF_8);
 
         //    String expectedIndexDocument =
         //        Files.readString(Path.of(new ClassPathResource(fileBaseName + ".json").getURI()));
 
-        String expectedIndexDocument = IOUtils.toString(new ClassPathResource(fileBaseName + ".json").getInputStream());
+        String expectedIndexDocument = IOUtils.toString(
+                new ClassPathResource(fileBaseName + ".json").getInputStream(), StandardCharsets.UTF_8);
 
         Metadata dbRecord = Metadata.builder()
                 .uuid(fileBaseName)

--- a/src/shared/database/README.md
+++ b/src/shared/database/README.md
@@ -1,0 +1,14 @@
+# Database module
+
+[Liquibase](https://www.liquibase.com/) is used to manage database schema creation and changes on a per-feature basis.
+
+Documentation about Liquibase can be found in the [Liquibase documentation](https://docs.liquibase.com/oss/implementation-guide-4-33/intro-to-liquibase).
+
+## Database initialization
+
+GeoNetwork 5 depends on the GeoNetwork 4 database module to initialize the database using Liquibase.
+
+Additional changes made by GeoNetwork 5 should be added in a new GeoNetwork 5 database module, 
+which will contain [changesets specific to GeoNetwork 5](src/main/resources/db/changesets).
+
+Both GeoNetwork 4 and GeoNetwork 5 can create or migrate the database.

--- a/src/shared/database/pom.xml
+++ b/src/shared/database/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    SPDX-FileCopyrightText: 2001 FAO-UN and others <geonetwork@osgeo.org>
+    SPDX-License-Identifier: GPL-2.0-or-later
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.geonetwork</groupId>
+    <artifactId>gn-shared</artifactId>
+    <version>5.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>gn-database</artifactId>
+  <name>GeoNetwork database</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.liquibase</groupId>
+      <artifactId>liquibase-core</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/shared/database/src/main/resources/db/changesets/10001-set-version.sql
+++ b/src/shared/database/src/main/resources/db/changesets/10001-set-version.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+--changeset francois:10001
+--preconditions onFail:HALT onError:HALT
+--precondition-sql-check expectedResult:1 SELECT COUNT(*) FROM settings WHERE name='system/platform/version' AND value='4.4.10';
+
+UPDATE Settings SET value='5.0.0' WHERE name='system/platform/version';

--- a/src/shared/domain/pom.xml
+++ b/src/shared/domain/pom.xml
@@ -18,6 +18,15 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.geonetwork-opensource</groupId>
+      <artifactId>gn-database</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geonetwork</groupId>
+      <artifactId>gn-database</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
     </dependency>

--- a/src/shared/pom.xml
+++ b/src/shared/pom.xml
@@ -21,6 +21,7 @@
 
   <modules>
     <module>testing</module>
+    <module>database</module>
     <module>configuration</module>
     <module>constants</module>
     <module>domain</module>


### PR DESCRIPTION
GeoNetwork 5 depends on the GeoNetwork 4 database module to initialize the database using Liquibase.

Additional changes made by GeoNetwork 5 should be added in a new GeoNetwork 5 database module, which will contain changesets specific to GeoNetwork 5.

Both GeoNetwork 4 and GeoNetwork 5 can create or migrate the database.

Related to https://github.com/geonetwork/core-geonetwork/pull/9146


Github can't build that branch because gn-database 4.4.10-SNAPSHOT does not exist in maven repo.

## Type of Change
Select one:
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
Closes/updates # (optional):

## Approach
<!-- Outline your solution and any key decisions. Bullet points are fine. -->

## How to Verify

* Build GN4 with https://github.com/geonetwork/core-geonetwork/pull/9146
* Build GN5 branch (which depends on gn-database 4.4.10-SNAPSHOT)
* Start GN5
* Database is created and GN5 changeset setting the version is also applied

<img width="573" height="226" alt="image" src="https://github.com/user-attachments/assets/f7308f30-12e3-4cb5-b041-83d1b624af44" />



## Checklist
- [ ] Code is formatted and linted
- [ ] All tests pass locally and in CI
- [ ] Tests updated (if applicable)
- [ ] Documentation updated (if applicable)

<!--
Optional: add any extra notes, credits (e.g., "Funded by ..."), or dependencies.
-->
