### PR TITLE
Configuration / Add option to disable the module

### DIFF
--- a/src/shared/configuration-management/src/main/java/org/geonetwork/configuration/ConfigurationInitializer.java
+++ b/src/shared/configuration-management/src/main/java/org/geonetwork/configuration/ConfigurationInitializer.java
@@ -7,6 +7,7 @@ package org.geonetwork.configuration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBooleanProperty;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 @Slf4j
 @Profile("!test") // Avoid running during unit tests unless specifically needed
+@ConditionalOnBooleanProperty(name = "spring.cloud.config.enabled", havingValue = true, matchIfMissing = true)
 public class ConfigurationInitializer implements CommandLineRunner {
 
     private final AppConfigRepository repository;


### PR DESCRIPTION
When running OGC API Records solo, we don't need the configuration module (at least for now). This will allow to use OGC API Records next to GN4 using the same database. Configuration module require one specific table to store the config.

## Description

## Type of Change
Select one:
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactoring

## Related Issue
Closes/updates # (optional):


## How to Verify

### Build GN5 docker image

```
mvn spring-boot:build-image -pl src/apps/geonetwork -Dspring-boot.build-image.imageName=gn5-dev -Dspring-boot.build-image.platform=linux/amd64 -Dspring-boot.build-image.cleanCache=true
```

### Add GN5 OGC API Records to GN4 docker compose


GN4 can be deploy with `geonetwork.MicroServicesProxy.targetUri` pointing to GN5 using docker:

Start with https://github.com/geonetwork/docker-geonetwork/tree/main/4.4.11 and adjust the following:

```
  GN_CONFIG_PROPERTIES: >-
    ...
    -Dgeonetwork.MicroServicesProxy.targetUri=http://ogc-api-records-service:8080/geonetwork/api


  ogc-api-records-service:
    image: docker.io/library/gn5-dev:latest
    hostname: ogc-api-records-service
    environment:
      SERVER_PORT: 8080
      SPRING_DATASOURCE_URL: jdbc:postgresql://database:5432/geonetwork
      SPRING_DATASOURCE_USERNAME: geonetwork
      SPRING_DATASOURCE_PASSWORD: geonetwork
      SPRING_LIQUIBASE_ENABLED: "false"
      SPRING_CLOUD_CONFIG_ENABLED: "false"
      GN5_BASE_URL: http://geonetwork.localhost/geonetwork
      GEONETWORK_INDEX_URL: http://elasticsearch:9200
      GEONETWORK_OPENAPI-RECORDS_LINKS_BASE-PATH: /api
      JAVA_OPTS: -Dfile.encoding=UTF-8
    healthcheck:
      test: "timeout 10s bash -c ':> /dev/tcp/127.0.0.1/8080' || exit 1"
      interval: 10s
      timeout: 2s
      retries: 10
    depends_on:
      geonetwork:
         condition: service_healthy
    networks:
      - gn-network
```

## Checklist
- [ ] Code is formatted and linted
- [ ] All tests pass locally and in CI
- [ ] Tests updated (if applicable)
- [ ] Documentation updated (if applicable)

<!--
Optional: add any extra notes, credits (e.g., "Funded by ..."), or dependencies.
-->
