### PR TITLE
Ogc api records facets and property mapping db backed configuration

### DIFF
--- a/src/modules/ogcapi-records/ogcapi-records-implementation/src/main/java/org/geonetwork/ogcapi/records/OgcApiConfigController.java
+++ b/src/modules/ogcapi-records/ogcapi-records-implementation/src/main/java/org/geonetwork/ogcapi/records/OgcApiConfigController.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: 2001 FAO-UN and others <geonetwork@osgeo.org>
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+package org.geonetwork.ogcapi.records;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.geonetwork.ogcapi.service.configuration.OgcApiPropertyMappingService;
+import org.geonetwork.ogcapi.service.configuration.OgcElasticFieldsMapperConfig;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Admin endpoints for managing the OGC API Records facets and property-mapping configuration. */
+@RestController
+@RequestMapping("/api/ogcapi/configuration")
+@RequiredArgsConstructor
+@Tag(name = "OGC API Configuration", description = "Manage OGC API Records facets and property-mapping config")
+public class OgcApiConfigController {
+
+    private final OgcApiPropertyMappingService configService;
+
+    @Operation(summary = "Get the current OGC API property-mapping configuration")
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    // @PreAuthorize("hasRole('Administrator')")
+    public OgcElasticFieldsMapperConfig getConfiguration() {
+        return configService.getConfig();
+    }
+
+    @Operation(summary = "Replace the OGC API property-mapping configuration")
+    @PutMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    //  @PreAuthorize("hasRole('Administrator')")
+    public OgcElasticFieldsMapperConfig updateConfiguration(@RequestBody OgcElasticFieldsMapperConfig newConfig) {
+        return configService.updateConfig(newConfig);
+    }
+
+    @Operation(
+            summary = "Get the current update sequence",
+            description = "Returns a counter incremented on every config update. "
+                    + "External containers can poll this to detect changes without a message queue.")
+    @GetMapping(path = "/update-sequence", produces = MediaType.APPLICATION_JSON_VALUE)
+    public long getUpdateSequence() {
+        return configService.getUpdateSequence();
+    }
+}

--- a/src/modules/ogcapi-records/ogcapi-records-implementation/src/main/java/org/geonetwork/ogcapi/records/OgcApiConfigController.java
+++ b/src/modules/ogcapi-records/ogcapi-records-implementation/src/main/java/org/geonetwork/ogcapi/records/OgcApiConfigController.java
@@ -39,13 +39,4 @@ public class OgcApiConfigController {
     public OgcElasticFieldsMapperConfig updateConfiguration(@RequestBody OgcElasticFieldsMapperConfig newConfig) {
         return configService.updateConfig(newConfig);
     }
-
-    @Operation(
-            summary = "Get the current update sequence",
-            description = "Returns a counter incremented on every config update. "
-                    + "External containers can poll this to detect changes without a message queue.")
-    @GetMapping(path = "/update-sequence", produces = MediaType.APPLICATION_JSON_VALUE)
-    public long getUpdateSequence() {
-        return configService.getUpdateSequence();
-    }
 }

--- a/src/modules/ogcapi-records/ogcapi-records-implementation/src/main/java/org/geonetwork/ogcapi/records/OgcApiConfigController.java
+++ b/src/modules/ogcapi-records/ogcapi-records-implementation/src/main/java/org/geonetwork/ogcapi/records/OgcApiConfigController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.geonetwork.ogcapi.service.configuration.OgcApiPropertyMappingService;
 import org.geonetwork.ogcapi.service.configuration.OgcElasticFieldsMapperConfig;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -27,14 +28,14 @@ public class OgcApiConfigController {
 
     @Operation(summary = "Get the current OGC API property-mapping configuration")
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-    // @PreAuthorize("hasRole('Administrator')")
+    @PreAuthorize("hasRole('Administrator')")
     public OgcElasticFieldsMapperConfig getConfiguration() {
         return configService.getConfig();
     }
 
     @Operation(summary = "Replace the OGC API property-mapping configuration")
     @PutMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    //  @PreAuthorize("hasRole('Administrator')")
+    @PreAuthorize("hasRole('Administrator')")
     public OgcElasticFieldsMapperConfig updateConfiguration(@RequestBody OgcElasticFieldsMapperConfig newConfig) {
         return configService.updateConfig(newConfig);
     }

--- a/src/modules/ogcapi-records/ogcapi-records-integration-tests/src/test/resources/dump.gn.sql
+++ b/src/modules/ogcapi-records/ogcapi-records-integration-tests/src/test/resources/dump.gn.sql
@@ -1122,6 +1122,126 @@ CREATE TABLE public.settings_ui (
 ALTER TABLE public.settings_ui OWNER TO postgres;
 
 --
+-- Name: ogcapi_property_mapping; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.ogcapi_property_mapping (
+    id character varying(255) NOT NULL,
+    default_bucket_count integer DEFAULT 10 NOT NULL,
+    update_sequence bigint DEFAULT 1 NOT NULL
+);
+
+
+ALTER TABLE public.ogcapi_property_mapping OWNER TO postgres;
+
+--
+-- Name: ogcapi_field_mapping; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.ogcapi_field_mapping (
+    id bigint NOT NULL,
+    config_id character varying(255) NOT NULL,
+    sort_order integer DEFAULT 0 NOT NULL,
+    ogc_property character varying(255),
+    elastic_property character varying(255),
+    index_record_property character varying(255),
+    type_override character varying(50),
+    sort_field_suffix character varying(255),
+    is_sortable boolean DEFAULT false,
+    is_queryable boolean DEFAULT false,
+    title character varying(255),
+    description text,
+    add_property_to_output boolean DEFAULT true
+);
+
+
+ALTER TABLE public.ogcapi_field_mapping OWNER TO postgres;
+
+--
+-- Name: ogcapi_field_mapping_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.ogcapi_field_mapping_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.ogcapi_field_mapping_id_seq OWNER TO postgres;
+
+ALTER TABLE ONLY public.ogcapi_field_mapping ALTER COLUMN id SET DEFAULT nextval('public.ogcapi_field_mapping_id_seq'::regclass);
+
+--
+-- Name: ogcapi_facet_config; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.ogcapi_facet_config (
+    id bigint NOT NULL,
+    field_mapping_id bigint NOT NULL,
+    sort_order integer DEFAULT 0 NOT NULL,
+    facet_name character varying(255),
+    facet_type character varying(50),
+    bucket_sorting character varying(50),
+    bucket_sorting_direction character varying(50),
+    bucket_count integer,
+    minimum_document_count integer DEFAULT 1 NOT NULL,
+    number_bucket_interval double precision,
+    calendar_interval_unit character varying(50)
+);
+
+
+ALTER TABLE public.ogcapi_facet_config OWNER TO postgres;
+
+--
+-- Name: ogcapi_facet_config_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.ogcapi_facet_config_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.ogcapi_facet_config_id_seq OWNER TO postgres;
+
+ALTER TABLE ONLY public.ogcapi_facet_config ALTER COLUMN id SET DEFAULT nextval('public.ogcapi_facet_config_id_seq'::regclass);
+
+--
+-- Name: ogcapi_filter_facet; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.ogcapi_filter_facet (
+    id bigint NOT NULL,
+    facet_config_id bigint NOT NULL,
+    sort_order integer DEFAULT 0 NOT NULL,
+    filter_name character varying(255),
+    filter_equation_cql text
+);
+
+
+ALTER TABLE public.ogcapi_filter_facet OWNER TO postgres;
+
+--
+-- Name: ogcapi_filter_facet_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.ogcapi_filter_facet_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.ogcapi_filter_facet_id_seq OWNER TO postgres;
+
+ALTER TABLE ONLY public.ogcapi_filter_facet ALTER COLUMN id SET DEFAULT nextval('public.ogcapi_filter_facet_id_seq'::regclass);
+
+--
 -- Name: sources; Type: TABLE; Schema: public; Owner: postgres
 --
 
@@ -29760,6 +29880,55 @@ ALTER TABLE ONLY public.settings
 
 ALTER TABLE ONLY public.settings_ui
     ADD CONSTRAINT settings_ui_pkey PRIMARY KEY (id);
+
+--
+-- Name: ogcapi_property_mapping ogcapi_property_mapping_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.ogcapi_property_mapping
+    ADD CONSTRAINT ogcapi_property_mapping_pkey PRIMARY KEY (id);
+
+--
+-- Name: ogcapi_field_mapping ogcapi_field_mapping_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.ogcapi_field_mapping
+    ADD CONSTRAINT ogcapi_field_mapping_pkey PRIMARY KEY (id);
+
+--
+-- Name: ogcapi_facet_config ogcapi_facet_config_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.ogcapi_facet_config
+    ADD CONSTRAINT ogcapi_facet_config_pkey PRIMARY KEY (id);
+
+--
+-- Name: ogcapi_filter_facet ogcapi_filter_facet_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.ogcapi_filter_facet
+    ADD CONSTRAINT ogcapi_filter_facet_pkey PRIMARY KEY (id);
+
+--
+-- Name: ogcapi_field_mapping fk_ogcapi_field_mapping_config; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.ogcapi_field_mapping
+    ADD CONSTRAINT fk_ogcapi_field_mapping_config FOREIGN KEY (config_id) REFERENCES public.ogcapi_property_mapping(id);
+
+--
+-- Name: ogcapi_facet_config fk_ogcapi_facet_config_field_mapping; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.ogcapi_facet_config
+    ADD CONSTRAINT fk_ogcapi_facet_config_field_mapping FOREIGN KEY (field_mapping_id) REFERENCES public.ogcapi_field_mapping(id);
+
+--
+-- Name: ogcapi_filter_facet fk_ogcapi_filter_facet_facet_config; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.ogcapi_filter_facet
+    ADD CONSTRAINT fk_ogcapi_filter_facet_facet_config FOREIGN KEY (facet_config_id) REFERENCES public.ogcapi_facet_config(id);
 
 
 --

--- a/src/shared/database/src/main/resources/db/changesets/00028-ogcapi-config.xml
+++ b/src/shared/database/src/main/resources/db/changesets/00028-ogcapi-config.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    SPDX-FileCopyrightText: 2001 FAO-UN and others <geonetwork@osgeo.org>
+    SPDX-License-Identifier: GPL-2.0-or-later
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet id="00028-ogcapi-property-mapping" author="geonetwork">
+        <createTable tableName="ogcapi_property_mapping">
+            <column name="id" type="VARCHAR(255)">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="ogcapi_property_mapping_pkey"/>
+            </column>
+            <column name="default_bucket_count" type="INTEGER" defaultValueNumeric="10">
+                <constraints nullable="false"/>
+            </column>
+            <column name="update_sequence" type="BIGINT" defaultValueNumeric="1">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="00028-ogcapi-field-mapping" author="geonetwork">
+        <createTable tableName="ogcapi_field_mapping">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="ogcapi_field_mapping_pkey"/>
+            </column>
+            <column name="config_id" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="sort_order" type="INTEGER" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="ogc_property" type="VARCHAR(255)"/>
+            <column name="elastic_property" type="VARCHAR(255)"/>
+            <column name="index_record_property" type="VARCHAR(255)"/>
+            <column name="type_override" type="VARCHAR(50)"/>
+            <column name="sort_field_suffix" type="VARCHAR(255)"/>
+            <column name="is_sortable" type="BOOLEAN" defaultValueBoolean="false"/>
+            <column name="is_queryable" type="BOOLEAN" defaultValueBoolean="false"/>
+            <column name="title" type="VARCHAR(255)"/>
+            <column name="description" type="TEXT"/>
+            <column name="add_property_to_output" type="BOOLEAN" defaultValueBoolean="true"/>
+        </createTable>
+        <addForeignKeyConstraint baseTableName="ogcapi_field_mapping"
+                                 baseColumnNames="config_id"
+                                 constraintName="fk_ogcapi_field_mapping_config"
+                                 referencedTableName="ogcapi_property_mapping"
+                                 referencedColumnNames="id"/>
+    </changeSet>
+
+    <changeSet id="00028-ogcapi-facet-config" author="geonetwork">
+        <createTable tableName="ogcapi_facet_config">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="ogcapi_facet_config_pkey"/>
+            </column>
+            <column name="field_mapping_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="sort_order" type="INTEGER" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="facet_name" type="VARCHAR(255)"/>
+            <column name="facet_type" type="VARCHAR(50)"/>
+            <column name="bucket_sorting" type="VARCHAR(50)"/>
+            <column name="bucket_sorting_direction" type="VARCHAR(50)"/>
+            <column name="bucket_count" type="INTEGER"/>
+            <column name="minimum_document_count" type="INTEGER" defaultValueNumeric="1">
+                <constraints nullable="false"/>
+            </column>
+            <column name="number_bucket_interval" type="DOUBLE PRECISION"/>
+            <column name="calendar_interval_unit" type="VARCHAR(50)"/>
+        </createTable>
+        <addForeignKeyConstraint baseTableName="ogcapi_facet_config"
+                                 baseColumnNames="field_mapping_id"
+                                 constraintName="fk_ogcapi_facet_config_field_mapping"
+                                 referencedTableName="ogcapi_field_mapping"
+                                 referencedColumnNames="id"/>
+    </changeSet>
+
+    <changeSet id="00028-ogcapi-filter-facet" author="geonetwork">
+        <createTable tableName="ogcapi_filter_facet">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="ogcapi_filter_facet_pkey"/>
+            </column>
+            <column name="facet_config_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="sort_order" type="INTEGER" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="filter_name" type="VARCHAR(255)"/>
+            <column name="filter_equation_cql" type="TEXT"/>
+        </createTable>
+        <addForeignKeyConstraint baseTableName="ogcapi_filter_facet"
+                                 baseColumnNames="facet_config_id"
+                                 constraintName="fk_ogcapi_filter_facet_facet_config"
+                                 referencedTableName="ogcapi_facet_config"
+                                 referencedColumnNames="id"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/shared/domain/src/main/java/org/geonetwork/domain/OgcApiFacetConfig.java
+++ b/src/shared/domain/src/main/java/org/geonetwork/domain/OgcApiFacetConfig.java
@@ -1,0 +1,77 @@
+/*
+ * SPDX-FileCopyrightText: 2001 FAO-UN and others <geonetwork@osgeo.org>
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+package org.geonetwork.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Entity
+@Table(name = "ogcapi_facet_config")
+public class OgcApiFacetConfig {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "field_mapping_id")
+    private OgcApiFieldMapping fieldMapping;
+
+    @Column(name = "sort_order", nullable = false)
+    private int sortOrder;
+
+    @Column(name = "facet_name", length = 255)
+    private String facetName;
+
+    @Column(name = "facet_type", length = 50)
+    private String facetType;
+
+    @Column(name = "bucket_sorting", length = 50)
+    private String bucketSorting;
+
+    @Column(name = "bucket_sorting_direction", length = 50)
+    private String bucketSortingDirection;
+
+    @Column(name = "bucket_count")
+    private Integer bucketCount;
+
+    @Builder.Default
+    @Column(name = "minimum_document_count", nullable = false)
+    private int minimumDocumentCount = 1;
+
+    @Column(name = "number_bucket_interval")
+    private Double numberBucketInterval;
+
+    @Column(name = "calendar_interval_unit", length = 50)
+    private String calendarIntervalUnit;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "facetConfig", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @OrderBy("sortOrder ASC")
+    private List<OgcApiFilterFacet> filters = new ArrayList<>();
+}

--- a/src/shared/domain/src/main/java/org/geonetwork/domain/OgcApiFieldMapping.java
+++ b/src/shared/domain/src/main/java/org/geonetwork/domain/OgcApiFieldMapping.java
@@ -1,0 +1,85 @@
+/*
+ * SPDX-FileCopyrightText: 2001 FAO-UN and others <geonetwork@osgeo.org>
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+package org.geonetwork.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Entity
+@Table(name = "ogcapi_field_mapping")
+public class OgcApiFieldMapping {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "config_id")
+    private OgcApiPropertyMapping config;
+
+    @Column(name = "sort_order", nullable = false)
+    private int sortOrder;
+
+    @Column(name = "ogc_property", length = 255)
+    private String ogcProperty;
+
+    @Column(name = "elastic_property", length = 255)
+    private String elasticProperty;
+
+    @Column(name = "index_record_property", length = 255)
+    private String indexRecordProperty;
+
+    @Column(name = "type_override", length = 50)
+    private String typeOverride;
+
+    @Column(name = "sort_field_suffix", length = 255)
+    private String sortFieldSuffix;
+
+    @Builder.Default
+    @Column(name = "is_sortable")
+    private Boolean isSortable = false;
+
+    @Builder.Default
+    @Column(name = "is_queryable")
+    private Boolean isQueryable = false;
+
+    @Column(name = "title", length = 255)
+    private String title;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @Builder.Default
+    @Column(name = "add_property_to_output")
+    private Boolean addPropertyToOutput = true;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "fieldMapping", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @OrderBy("sortOrder ASC")
+    private List<OgcApiFacetConfig> facets = new ArrayList<>();
+}

--- a/src/shared/domain/src/main/java/org/geonetwork/domain/OgcApiFilterFacet.java
+++ b/src/shared/domain/src/main/java/org/geonetwork/domain/OgcApiFilterFacet.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: 2001 FAO-UN and others <geonetwork@osgeo.org>
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+package org.geonetwork.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Entity
+@Table(name = "ogcapi_filter_facet")
+public class OgcApiFilterFacet {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "facet_config_id")
+    private OgcApiFacetConfig facetConfig;
+
+    @Column(name = "sort_order", nullable = false)
+    private int sortOrder;
+
+    @Column(name = "filter_name", length = 255)
+    private String filterName;
+
+    @Column(name = "filter_equation_cql", columnDefinition = "TEXT")
+    private String filterEquationCql;
+}

--- a/src/shared/domain/src/main/java/org/geonetwork/domain/OgcApiPropertyMapping.java
+++ b/src/shared/domain/src/main/java/org/geonetwork/domain/OgcApiPropertyMapping.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: 2001 FAO-UN and others <geonetwork@osgeo.org>
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+package org.geonetwork.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Entity
+@Table(name = "ogcapi_property_mapping")
+public class OgcApiPropertyMapping {
+
+    @Id
+    @Column(name = "id", nullable = false, length = 255)
+    private String id;
+
+    @Column(name = "default_bucket_count", nullable = false)
+    @Builder.Default
+    private int defaultBucketCount = 10;
+
+    @Builder.Default
+    @Column(name = "update_sequence", nullable = false)
+    private Long updateSequence = 1L;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "config", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @OrderBy("sortOrder ASC")
+    private List<OgcApiFieldMapping> fields = new ArrayList<>();
+}

--- a/src/shared/domain/src/main/java/org/geonetwork/domain/repository/OgcApiPropertyMappingRepository.java
+++ b/src/shared/domain/src/main/java/org/geonetwork/domain/repository/OgcApiPropertyMappingRepository.java
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: 2001 FAO-UN and others <geonetwork@osgeo.org>
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+package org.geonetwork.domain.repository;
+
+import org.geonetwork.domain.OgcApiPropertyMapping;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OgcApiPropertyMappingRepository extends JpaRepository<OgcApiPropertyMapping, String> {}

--- a/src/shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/configuration/OgcApiConfigChangedEvent.java
+++ b/src/shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/configuration/OgcApiConfigChangedEvent.java
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: 2001 FAO-UN and others <geonetwork@osgeo.org>
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+package org.geonetwork.ogcapi.service.configuration;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+/** Fired when the OGC API property-mapping configuration is updated via the admin REST API. */
+@Getter
+public class OgcApiConfigChangedEvent extends ApplicationEvent {
+
+    private final long updateSequence;
+
+    public OgcApiConfigChangedEvent(Object source, long updateSequence) {
+        super(source);
+        this.updateSequence = updateSequence;
+    }
+}

--- a/src/shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/configuration/OgcApiPropertyMappingService.java
+++ b/src/shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/configuration/OgcApiPropertyMappingService.java
@@ -7,7 +7,6 @@ package org.geonetwork.ogcapi.service.configuration;
 import jakarta.annotation.PostConstruct;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.geonetwork.domain.OgcApiFacetConfig;
@@ -77,9 +76,9 @@ public class OgcApiPropertyMappingService {
                 .build());
 
         entity.getFields().clear();
-        AtomicInteger fieldOrder = new AtomicInteger(0);
+        int fieldOrder = 0;
         for (OgcElasticFieldMapperConfig fieldConfig : newConfig.getFields()) {
-            OgcApiFieldMapping fieldEntity = toFieldEntity(fieldConfig, entity, fieldOrder.getAndIncrement());
+            OgcApiFieldMapping fieldEntity = toFieldEntity(fieldConfig, entity, fieldOrder++);
             entity.getFields().add(fieldEntity);
         }
         entity.setDefaultBucketCount(newConfig.getDefaultBucketCount());
@@ -165,9 +164,9 @@ public class OgcApiPropertyMappingService {
                 .defaultBucketCount(yaml.getDefaultBucketCount())
                 .updateSequence(1L)
                 .build();
-        AtomicInteger fieldOrder = new AtomicInteger(0);
+        int fieldOrder = 0;
         for (OgcElasticFieldMapperConfig fieldConfig : yaml.getFields()) {
-            OgcApiFieldMapping fieldEntity = toFieldEntity(fieldConfig, entity, fieldOrder.getAndIncrement());
+            OgcApiFieldMapping fieldEntity = toFieldEntity(fieldConfig, entity, fieldOrder++);
             entity.getFields().add(fieldEntity);
         }
         return entity;
@@ -192,10 +191,10 @@ public class OgcApiPropertyMappingService {
                 .description(fieldConfig.getDescription())
                 .addPropertyToOutput(fieldConfig.getAddPropertyToOutput())
                 .build();
-        AtomicInteger facetOrder = new AtomicInteger(0);
+        int facetOrder = 0;
         if (fieldConfig.getFacetsConfig() != null) {
             for (OgcFacetConfig facetConfig : fieldConfig.getFacetsConfig()) {
-                OgcApiFacetConfig facetEntity = toFacetEntity(facetConfig, fieldEntity, facetOrder.getAndIncrement());
+                OgcApiFacetConfig facetEntity = toFacetEntity(facetConfig, fieldEntity, facetOrder++);
                 fieldEntity.getFacets().add(facetEntity);
             }
         }
@@ -227,10 +226,10 @@ public class OgcApiPropertyMappingService {
                                 ? facetConfig.getCalendarIntervalUnit().name()
                                 : null)
                 .build();
-        AtomicInteger filterOrder = new AtomicInteger(0);
+        int filterOrder = 0;
         if (facetConfig.getFilters() != null) {
             for (FilterFacetInfo filterInfo : facetConfig.getFilters()) {
-                OgcApiFilterFacet filterEntity = toFilterEntity(filterInfo, facetEntity, filterOrder.getAndIncrement());
+                OgcApiFilterFacet filterEntity = toFilterEntity(filterInfo, facetEntity, filterOrder++);
                 facetEntity.getFilters().add(filterEntity);
             }
         }

--- a/src/shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/configuration/OgcApiPropertyMappingService.java
+++ b/src/shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/configuration/OgcApiPropertyMappingService.java
@@ -56,14 +56,6 @@ public class OgcApiPropertyMappingService {
         return toConfig(entity);
     }
 
-    /** Returns the current update sequence counter from the DB. */
-    public long getUpdateSequence() {
-        return repository
-                .findById(CONFIG_ID)
-                .map(OgcApiPropertyMapping::getUpdateSequence)
-                .orElse(0L);
-    }
-
     /**
      * Persists a new configuration, increments the update sequence, and fires {@link OgcApiConfigChangedEvent} so
      * in-JVM listeners can reload their caches.

--- a/src/shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/configuration/OgcApiPropertyMappingService.java
+++ b/src/shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/configuration/OgcApiPropertyMappingService.java
@@ -1,0 +1,248 @@
+/*
+ * SPDX-FileCopyrightText: 2001 FAO-UN and others <geonetwork@osgeo.org>
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+package org.geonetwork.ogcapi.service.configuration;
+
+import jakarta.annotation.PostConstruct;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.geonetwork.domain.OgcApiFacetConfig;
+import org.geonetwork.domain.OgcApiFieldMapping;
+import org.geonetwork.domain.OgcApiFilterFacet;
+import org.geonetwork.domain.OgcApiPropertyMapping;
+import org.geonetwork.domain.repository.OgcApiPropertyMappingRepository;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Manages the OGC API property-mapping configuration in the database.
+ *
+ * <p>On first startup, seeds the DB from the YAML-bound {@link OgcElasticFieldsMapperConfig}. Subsequent reads come
+ * from the DB. Updates increment the {@code update_sequence} counter and publish an {@link OgcApiConfigChangedEvent} so
+ * in-memory caches (e.g. {@code DynamicPropertiesFacade}) can reload.
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class OgcApiPropertyMappingService {
+
+    static final String CONFIG_ID = "property-mapping";
+
+    private final OgcApiPropertyMappingRepository repository;
+    private final OgcElasticFieldsMapperConfig yamlConfig;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @PostConstruct
+    void seedFromYamlIfAbsent() {
+        if (repository.existsById(CONFIG_ID)) {
+            return;
+        }
+        OgcApiPropertyMapping entity = buildEntityFromYaml(yamlConfig);
+        repository.save(entity);
+        log.info("Seeded OGC API property-mapping config from YAML into DB.");
+    }
+
+    /** Returns the current configuration, loaded from the DB. */
+    @Transactional(readOnly = true)
+    public OgcElasticFieldsMapperConfig getConfig() {
+        OgcApiPropertyMapping entity = repository
+                .findById(CONFIG_ID)
+                .orElseThrow(
+                        () -> new IllegalStateException("OGC API config row missing from DB (id=" + CONFIG_ID + ")"));
+        return toConfig(entity);
+    }
+
+    /** Returns the current update sequence counter from the DB. */
+    public long getUpdateSequence() {
+        return repository
+                .findById(CONFIG_ID)
+                .map(OgcApiPropertyMapping::getUpdateSequence)
+                .orElse(0L);
+    }
+
+    /**
+     * Persists a new configuration, increments the update sequence, and fires {@link OgcApiConfigChangedEvent} so
+     * in-JVM listeners can reload their caches.
+     */
+    @Transactional
+    public OgcElasticFieldsMapperConfig updateConfig(OgcElasticFieldsMapperConfig newConfig) {
+        OgcApiPropertyMapping entity = repository.findById(CONFIG_ID).orElseGet(() -> OgcApiPropertyMapping.builder()
+                .id(CONFIG_ID)
+                .updateSequence(0L)
+                .build());
+
+        entity.getFields().clear();
+        AtomicInteger fieldOrder = new AtomicInteger(0);
+        for (OgcElasticFieldMapperConfig fieldConfig : newConfig.getFields()) {
+            OgcApiFieldMapping fieldEntity = toFieldEntity(fieldConfig, entity, fieldOrder.getAndIncrement());
+            entity.getFields().add(fieldEntity);
+        }
+        entity.setDefaultBucketCount(newConfig.getDefaultBucketCount());
+        entity.setUpdateSequence(entity.getUpdateSequence() + 1);
+        repository.save(entity);
+
+        eventPublisher.publishEvent(new OgcApiConfigChangedEvent(this, entity.getUpdateSequence()));
+        log.info("OGC API property-mapping config updated (updateSequence={}).", entity.getUpdateSequence());
+        return newConfig;
+    }
+
+    // --- Entity → POJO mapping ---
+
+    private OgcElasticFieldsMapperConfig toConfig(OgcApiPropertyMapping entity) {
+        OgcElasticFieldsMapperConfig config = new OgcElasticFieldsMapperConfig();
+        config.setDefaultBucketCount(entity.getDefaultBucketCount());
+        List<OgcElasticFieldMapperConfig> fields = new ArrayList<>();
+        for (OgcApiFieldMapping fieldEntity : entity.getFields()) {
+            fields.add(toFieldConfig(fieldEntity));
+        }
+        config.setFields(fields);
+        return config;
+    }
+
+    private OgcElasticFieldMapperConfig toFieldConfig(OgcApiFieldMapping fieldEntity) {
+        OgcElasticFieldMapperConfig field = new OgcElasticFieldMapperConfig();
+        field.setOgcProperty(fieldEntity.getOgcProperty());
+        field.setElasticProperty(fieldEntity.getElasticProperty());
+        field.setIndexRecordProperty(fieldEntity.getIndexRecordProperty());
+        field.setTypeOverride(
+                fieldEntity.getTypeOverride() != null ? OverrideType.valueOf(fieldEntity.getTypeOverride()) : null);
+        field.setSortFieldSuffix(fieldEntity.getSortFieldSuffix());
+        field.setIsSortable(fieldEntity.getIsSortable());
+        field.setIsQueryable(fieldEntity.getIsQueryable());
+        field.setTitle(fieldEntity.getTitle());
+        field.setDescription(fieldEntity.getDescription());
+        field.setAddPropertyToOutput(fieldEntity.getAddPropertyToOutput());
+        List<OgcFacetConfig> facets = new ArrayList<>();
+        for (OgcApiFacetConfig facetEntity : fieldEntity.getFacets()) {
+            facets.add(toFacetConfig(facetEntity));
+        }
+        field.setFacetsConfig(facets);
+        return field;
+    }
+
+    private OgcFacetConfig toFacetConfig(OgcApiFacetConfig facetEntity) {
+        OgcFacetConfig facet = new OgcFacetConfig();
+        facet.setFacetName(facetEntity.getFacetName());
+        facet.setFacetType(facetEntity.getFacetType() != null ? FacetType.valueOf(facetEntity.getFacetType()) : null);
+        facet.setBucketSorting(
+                facetEntity.getBucketSorting() != null ? BucketSorting.valueOf(facetEntity.getBucketSorting()) : null);
+        facet.setBucketSortingDirection(
+                facetEntity.getBucketSortingDirection() != null
+                        ? BucketSortingDirection.valueOf(facetEntity.getBucketSortingDirection())
+                        : null);
+        facet.setBucketCount(facetEntity.getBucketCount());
+        facet.setMinimumDocumentCount(facetEntity.getMinimumDocumentCount());
+        facet.setNumberBucketInterval(facetEntity.getNumberBucketInterval());
+        facet.setCalendarIntervalUnit(
+                facetEntity.getCalendarIntervalUnit() != null
+                        ? CalendarIntervalUnit.valueOf(facetEntity.getCalendarIntervalUnit())
+                        : null);
+        List<FilterFacetInfo> filters = new ArrayList<>();
+        for (OgcApiFilterFacet filterEntity : facetEntity.getFilters()) {
+            filters.add(toFilterInfo(filterEntity));
+        }
+        facet.setFilters(filters);
+        return facet;
+    }
+
+    private FilterFacetInfo toFilterInfo(OgcApiFilterFacet filterEntity) {
+        FilterFacetInfo filter = new FilterFacetInfo();
+        filter.setFilterName(filterEntity.getFilterName());
+        filter.setFilterEquationCql(filterEntity.getFilterEquationCql());
+        return filter;
+    }
+
+    // --- POJO → Entity mapping ---
+
+    private OgcApiPropertyMapping buildEntityFromYaml(OgcElasticFieldsMapperConfig yaml) {
+        OgcApiPropertyMapping entity = OgcApiPropertyMapping.builder()
+                .id(CONFIG_ID)
+                .defaultBucketCount(yaml.getDefaultBucketCount())
+                .updateSequence(1L)
+                .build();
+        AtomicInteger fieldOrder = new AtomicInteger(0);
+        for (OgcElasticFieldMapperConfig fieldConfig : yaml.getFields()) {
+            OgcApiFieldMapping fieldEntity = toFieldEntity(fieldConfig, entity, fieldOrder.getAndIncrement());
+            entity.getFields().add(fieldEntity);
+        }
+        return entity;
+    }
+
+    private OgcApiFieldMapping toFieldEntity(
+            OgcElasticFieldMapperConfig fieldConfig, OgcApiPropertyMapping parent, int order) {
+        OgcApiFieldMapping fieldEntity = OgcApiFieldMapping.builder()
+                .config(parent)
+                .sortOrder(order)
+                .ogcProperty(fieldConfig.getOgcProperty())
+                .elasticProperty(fieldConfig.getElasticProperty())
+                .indexRecordProperty(fieldConfig.getIndexRecordProperty())
+                .typeOverride(
+                        fieldConfig.getTypeOverride() != null
+                                ? fieldConfig.getTypeOverride().name()
+                                : null)
+                .sortFieldSuffix(fieldConfig.getSortFieldSuffix())
+                .isSortable(fieldConfig.getIsSortable())
+                .isQueryable(fieldConfig.getIsQueryable())
+                .title(fieldConfig.getTitle())
+                .description(fieldConfig.getDescription())
+                .addPropertyToOutput(fieldConfig.getAddPropertyToOutput())
+                .build();
+        AtomicInteger facetOrder = new AtomicInteger(0);
+        if (fieldConfig.getFacetsConfig() != null) {
+            for (OgcFacetConfig facetConfig : fieldConfig.getFacetsConfig()) {
+                OgcApiFacetConfig facetEntity = toFacetEntity(facetConfig, fieldEntity, facetOrder.getAndIncrement());
+                fieldEntity.getFacets().add(facetEntity);
+            }
+        }
+        return fieldEntity;
+    }
+
+    private OgcApiFacetConfig toFacetEntity(OgcFacetConfig facetConfig, OgcApiFieldMapping parent, int order) {
+        OgcApiFacetConfig facetEntity = OgcApiFacetConfig.builder()
+                .fieldMapping(parent)
+                .sortOrder(order)
+                .facetName(facetConfig.getFacetName())
+                .facetType(
+                        facetConfig.getFacetType() != null
+                                ? facetConfig.getFacetType().name()
+                                : null)
+                .bucketSorting(
+                        facetConfig.getBucketSorting() != null
+                                ? facetConfig.getBucketSorting().name()
+                                : null)
+                .bucketSortingDirection(
+                        facetConfig.getBucketSortingDirection() != null
+                                ? facetConfig.getBucketSortingDirection().name()
+                                : null)
+                .bucketCount(facetConfig.getBucketCount())
+                .minimumDocumentCount(facetConfig.getMinimumDocumentCount())
+                .numberBucketInterval(facetConfig.getNumberBucketInterval())
+                .calendarIntervalUnit(
+                        facetConfig.getCalendarIntervalUnit() != null
+                                ? facetConfig.getCalendarIntervalUnit().name()
+                                : null)
+                .build();
+        AtomicInteger filterOrder = new AtomicInteger(0);
+        if (facetConfig.getFilters() != null) {
+            for (FilterFacetInfo filterInfo : facetConfig.getFilters()) {
+                OgcApiFilterFacet filterEntity = toFilterEntity(filterInfo, facetEntity, filterOrder.getAndIncrement());
+                facetEntity.getFilters().add(filterEntity);
+            }
+        }
+        return facetEntity;
+    }
+
+    private OgcApiFilterFacet toFilterEntity(FilterFacetInfo filterInfo, OgcApiFacetConfig parent, int order) {
+        return OgcApiFilterFacet.builder()
+                .facetConfig(parent)
+                .sortOrder(order)
+                .filterName(filterInfo.getFilterName())
+                .filterEquationCql(filterInfo.getFilterEquationCql())
+                .build();
+    }
+}

--- a/src/shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/configuration/OgcElasticFieldsMapperConfig.java
+++ b/src/shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/configuration/OgcElasticFieldsMapperConfig.java
@@ -9,9 +9,9 @@ import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
 
-@Configuration
+@Component
 @ConfigurationProperties(prefix = "geonetwork.openapi-records.ogcapi-property-mapping")
 @Getter
 @Setter

--- a/src/shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/indexConvert/dynamic/DynamicPropertiesFacade.java
+++ b/src/shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/indexConvert/dynamic/DynamicPropertiesFacade.java
@@ -4,6 +4,7 @@
  */
 package org.geonetwork.ogcapi.service.indexConvert.dynamic;
 
+import jakarta.annotation.PostConstruct;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -11,11 +12,14 @@ import org.geonetwork.index.model.record.IndexRecord;
 import org.geonetwork.ogcapi.records.generated.model.OgcApiRecordsJsonPropertyDto;
 import org.geonetwork.ogcapi.records.generated.model.OgcApiRecordsJsonSchemaDto;
 import org.geonetwork.ogcapi.records.generated.model.OgcApiRecordsRecordGeoJSONDto;
+import org.geonetwork.ogcapi.service.configuration.OgcApiConfigChangedEvent;
+import org.geonetwork.ogcapi.service.configuration.OgcApiPropertyMappingService;
 import org.geonetwork.ogcapi.service.configuration.OgcElasticFieldMapperConfig;
 import org.geonetwork.ogcapi.service.configuration.OgcElasticFieldsMapperConfig;
 import org.geonetwork.ogcapi.service.configuration.OgcFacetConfig;
 import org.geonetwork.ogcapi.service.configuration.SimpleType;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 /**
@@ -27,13 +31,26 @@ import org.springframework.stereotype.Component;
 public class DynamicPropertiesFacade {
 
     @Autowired
-    private OgcElasticFieldsMapperConfig config;
+    private OgcApiPropertyMappingService configService;
 
     @Autowired
     ElasticTypingSystem elasticTypingSystem;
 
     @Autowired
     ExtraElasticPropertiesService extraElasticPropertiesService;
+
+    private OgcElasticFieldsMapperConfig config;
+
+    @PostConstruct
+    void loadConfig() {
+        config = configService.getConfig();
+    }
+
+    @EventListener
+    void onConfigChanged(OgcApiConfigChangedEvent event) {
+        config = configService.getConfig();
+        elasticTypingSystem.refresh(config);
+    }
 
     public void injectFacetsIntoResponse(
             IndexRecord indexRecord, String iso3lang, OgcApiRecordsRecordGeoJSONDto result) {

--- a/src/shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/indexConvert/dynamic/DynamicPropertiesFacade.java
+++ b/src/shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/indexConvert/dynamic/DynamicPropertiesFacade.java
@@ -19,8 +19,9 @@ import org.geonetwork.ogcapi.service.configuration.OgcElasticFieldsMapperConfig;
 import org.geonetwork.ogcapi.service.configuration.OgcFacetConfig;
 import org.geonetwork.ogcapi.service.configuration.SimpleType;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 /**
  * This gives a higher level api to the Dynamic properties.
@@ -39,14 +40,14 @@ public class DynamicPropertiesFacade {
     @Autowired
     ExtraElasticPropertiesService extraElasticPropertiesService;
 
-    private OgcElasticFieldsMapperConfig config;
+    private volatile OgcElasticFieldsMapperConfig config;
 
     @PostConstruct
     void loadConfig() {
         config = configService.getConfig();
     }
 
-    @EventListener
+   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     void onConfigChanged(OgcApiConfigChangedEvent event) {
         config = configService.getConfig();
         elasticTypingSystem.refresh(config);

--- a/src/shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/indexConvert/dynamic/DynamicPropertiesFacade.java
+++ b/src/shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/indexConvert/dynamic/DynamicPropertiesFacade.java
@@ -47,7 +47,7 @@ public class DynamicPropertiesFacade {
         config = configService.getConfig();
     }
 
-   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     void onConfigChanged(OgcApiConfigChangedEvent event) {
         config = configService.getConfig();
         elasticTypingSystem.refresh(config);

--- a/src/shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/indexConvert/dynamic/ElasticTypingSystem.java
+++ b/src/shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/indexConvert/dynamic/ElasticTypingSystem.java
@@ -47,10 +47,10 @@ public class ElasticTypingSystem {
     //    private Map<String, PropertyVariant> rawElasticTypes = new HashMap<String, PropertyVariant>();
 
     /** final elastic types key is from config.fields.elasticProperty */
-    private Map<String, ElasticTypeInfo> finalElasticTypes = new HashMap<>();
+    private volatile Map<String, ElasticTypeInfo> finalElasticTypes = new HashMap<>();
 
     /** final elastic types key is from config.fields.ogcproperty */
-    private Map<String, ElasticTypeInfo> finalElasticTypesByOgc;
+    private volatile Map<String, ElasticTypeInfo> finalElasticTypesByOgc;
 
     public ElasticTypingSystem(
             OgcElasticFieldsMapperConfig config,
@@ -75,6 +75,23 @@ public class ElasticTypingSystem {
             IndexClient client) {
 
         this(config, indexRecordName, getIndexInfo(client, indexRecordName));
+    }
+
+    /**
+     * Rebuilds the type maps from a new config (called when the DB config is updated).
+     *
+     * @param newConfig updated field-mapping configuration
+     */
+    public void refresh(OgcElasticFieldsMapperConfig newConfig) {
+        Map<String, ElasticTypeInfo> byElastic = new HashMap<>();
+        Map<String, ElasticTypeInfo> byOgc = new HashMap<>();
+        for (var field : newConfig.getFields()) {
+            var finalType = computeElasticTypeInfo(field);
+            byElastic.put(field.getElasticProperty(), finalType);
+            byOgc.put(field.getOgcProperty(), finalType);
+        }
+        this.finalElasticTypes = byElastic;
+        this.finalElasticTypesByOgc = byOgc;
     }
 
     /**

--- a/src/shared/ogcapi-records/src/test/java/org/geonetwork/ogcapi/service/configuration/OgcApiPropertyMappingServiceTest.java
+++ b/src/shared/ogcapi-records/src/test/java/org/geonetwork/ogcapi/service/configuration/OgcApiPropertyMappingServiceTest.java
@@ -1,0 +1,174 @@
+/*
+ * SPDX-FileCopyrightText: 2001 FAO-UN and others <geonetwork@osgeo.org>
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+package org.geonetwork.ogcapi.service.configuration;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.geonetwork.domain.OgcApiFacetConfig;
+import org.geonetwork.domain.OgcApiFieldMapping;
+import org.geonetwork.domain.OgcApiPropertyMapping;
+import org.geonetwork.domain.repository.OgcApiPropertyMappingRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.context.ApplicationEventPublisher;
+
+class OgcApiPropertyMappingServiceTest {
+
+    private OgcApiPropertyMappingRepository repository;
+    private OgcElasticFieldsMapperConfig yamlConfig;
+    private ApplicationEventPublisher eventPublisher;
+    private OgcApiPropertyMappingService service;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(OgcApiPropertyMappingRepository.class);
+        yamlConfig = new OgcElasticFieldsMapperConfig();
+        eventPublisher = mock(ApplicationEventPublisher.class);
+        service = new OgcApiPropertyMappingService(repository, yamlConfig, eventPublisher);
+    }
+
+    @Test
+    void seedFromYamlIfAbsent_insertsRowWhenMissing() {
+        when(repository.existsById(OgcApiPropertyMappingService.CONFIG_ID)).thenReturn(false);
+        when(repository.save(any(OgcApiPropertyMapping.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.seedFromYamlIfAbsent();
+
+        var captor = ArgumentCaptor.forClass(OgcApiPropertyMapping.class);
+        verify(repository).save(captor.capture());
+        OgcApiPropertyMapping saved = captor.getValue();
+        assertEquals(OgcApiPropertyMappingService.CONFIG_ID, saved.getId());
+        assertEquals(1L, saved.getUpdateSequence());
+    }
+
+    @Test
+    void seedFromYamlIfAbsent_doesNotInsertWhenRowExists() {
+        when(repository.existsById(OgcApiPropertyMappingService.CONFIG_ID)).thenReturn(true);
+
+        service.seedFromYamlIfAbsent();
+
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    void getConfig_deserializesFromDb() {
+        OgcApiFacetConfig facetEntity = OgcApiFacetConfig.builder()
+                .id(1L)
+                .sortOrder(0)
+                .facetName("myFacet")
+                .facetType(FacetType.TERM.name())
+                .bucketSorting(BucketSorting.COUNT.name())
+                .bucketSortingDirection(BucketSortingDirection.DESCENDING.name())
+                .minimumDocumentCount(1)
+                .build();
+
+        List<OgcApiFacetConfig> facets = new ArrayList<>();
+        facets.add(facetEntity);
+
+        OgcApiFieldMapping fieldEntity = OgcApiFieldMapping.builder()
+                .id(1L)
+                .sortOrder(0)
+                .ogcProperty("myProp")
+                .isSortable(false)
+                .isQueryable(false)
+                .addPropertyToOutput(true)
+                .build();
+        // set facets via setter since builder does not allow mutation after build
+        fieldEntity.setFacets(facets);
+        facetEntity.setFieldMapping(fieldEntity);
+
+        List<OgcApiFieldMapping> fields = new ArrayList<>();
+        fields.add(fieldEntity);
+
+        OgcApiPropertyMapping entity = OgcApiPropertyMapping.builder()
+                .id(OgcApiPropertyMappingService.CONFIG_ID)
+                .defaultBucketCount(10)
+                .updateSequence(3L)
+                .build();
+        entity.setFields(fields);
+        fieldEntity.setConfig(entity);
+
+        when(repository.findById(OgcApiPropertyMappingService.CONFIG_ID)).thenReturn(Optional.of(entity));
+
+        OgcElasticFieldsMapperConfig result = service.getConfig();
+
+        assertEquals(1, result.getFields().size());
+        assertEquals("myProp", result.getFields().get(0).getOgcProperty());
+        assertEquals(1, result.getFields().get(0).getFacetsConfig().size());
+        assertEquals(
+                "myFacet", result.getFields().get(0).getFacetsConfig().get(0).getFacetName());
+        assertEquals(
+                FacetType.TERM,
+                result.getFields().get(0).getFacetsConfig().get(0).getFacetType());
+    }
+
+    @Test
+    void getConfig_throwsWhenRowMissing() {
+        when(repository.findById(OgcApiPropertyMappingService.CONFIG_ID)).thenReturn(Optional.empty());
+
+        assertThrows(IllegalStateException.class, () -> service.getConfig());
+    }
+
+    @Test
+    void getUpdateSequence_returnsValueFromDb() {
+        OgcApiPropertyMapping entity = OgcApiPropertyMapping.builder()
+                .id(OgcApiPropertyMappingService.CONFIG_ID)
+                .updateSequence(7L)
+                .build();
+        when(repository.findById(OgcApiPropertyMappingService.CONFIG_ID)).thenReturn(Optional.of(entity));
+
+        assertEquals(7L, service.getUpdateSequence());
+    }
+
+    @Test
+    void getUpdateSequence_returnsZeroWhenMissing() {
+        when(repository.findById(OgcApiPropertyMappingService.CONFIG_ID)).thenReturn(Optional.empty());
+
+        assertEquals(0L, service.getUpdateSequence());
+    }
+
+    @Test
+    void updateConfig_incrementsSequenceAndFiresEvent() {
+        List<OgcApiFieldMapping> mutableFields = new ArrayList<>();
+        OgcApiPropertyMapping existing = OgcApiPropertyMapping.builder()
+                .id(OgcApiPropertyMappingService.CONFIG_ID)
+                .updateSequence(4L)
+                .build();
+        existing.setFields(mutableFields);
+
+        when(repository.findById(OgcApiPropertyMappingService.CONFIG_ID)).thenReturn(Optional.of(existing));
+        when(repository.save(any(OgcApiPropertyMapping.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var newConfig = new OgcElasticFieldsMapperConfig();
+        service.updateConfig(newConfig);
+
+        var captor = ArgumentCaptor.forClass(OgcApiPropertyMapping.class);
+        verify(repository).save(captor.capture());
+        assertEquals(5L, captor.getValue().getUpdateSequence());
+
+        var eventCaptor = ArgumentCaptor.forClass(OgcApiConfigChangedEvent.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        assertEquals(5L, eventCaptor.getValue().getUpdateSequence());
+    }
+
+    @Test
+    void updateConfig_createsNewRowWhenMissing() {
+        when(repository.findById(OgcApiPropertyMappingService.CONFIG_ID)).thenReturn(Optional.empty());
+        when(repository.save(any(OgcApiPropertyMapping.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var newConfig = new OgcElasticFieldsMapperConfig();
+        service.updateConfig(newConfig);
+
+        var captor = ArgumentCaptor.forClass(OgcApiPropertyMapping.class);
+        verify(repository).save(captor.capture());
+        assertEquals(1L, captor.getValue().getUpdateSequence());
+    }
+}

--- a/src/shared/ogcapi-records/src/test/java/org/geonetwork/ogcapi/service/configuration/OgcApiPropertyMappingServiceTest.java
+++ b/src/shared/ogcapi-records/src/test/java/org/geonetwork/ogcapi/service/configuration/OgcApiPropertyMappingServiceTest.java
@@ -118,24 +118,6 @@ class OgcApiPropertyMappingServiceTest {
     }
 
     @Test
-    void getUpdateSequence_returnsValueFromDb() {
-        OgcApiPropertyMapping entity = OgcApiPropertyMapping.builder()
-                .id(OgcApiPropertyMappingService.CONFIG_ID)
-                .updateSequence(7L)
-                .build();
-        when(repository.findById(OgcApiPropertyMappingService.CONFIG_ID)).thenReturn(Optional.of(entity));
-
-        assertEquals(7L, service.getUpdateSequence());
-    }
-
-    @Test
-    void getUpdateSequence_returnsZeroWhenMissing() {
-        when(repository.findById(OgcApiPropertyMappingService.CONFIG_ID)).thenReturn(Optional.empty());
-
-        assertEquals(0L, service.getUpdateSequence());
-    }
-
-    @Test
     void updateConfig_incrementsSequenceAndFiresEvent() {
         List<OgcApiFieldMapping> mutableFields = new ArrayList<>();
         OgcApiPropertyMapping existing = OgcApiPropertyMapping.builder()


### PR DESCRIPTION
<!--
  Please fill out the sections below to help reviewers quickly understand and test your change.
  Keep it concise and focused.
-->

<!--
    As PR title use a short, descriptive title in imperative form (e.g., "Fix map zoom regression").
-->
# OGC API Records Facets and Property-Mapping DB-backed Configuration (Issue #165)
## Description
Previously the OGC API Records facets and property-mapping configuration lived entirely in
`config/application-ogcapi-records.yml`. This change moves
the configuration into the database so it can be updated at runtime via a REST API.


<!-- Describe what the change does and why. Keep it to 1–2 sentences. -->

## Type of Change
Select one:
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
Closes/updates # (optional):

## Approach
<!-- Outline your solution and any key decisions. Bullet points are fine. -->

## Checklist
- [ ] Code is formatted and linted
- [ ] All tests pass locally and in CI
- [ ] Tests updated (if applicable)
- [ ] Documentation updated (if applicable)

<!--
Optional: add any extra notes, credits (e.g., "Funded by ..."), or dependencies.
-->

## What changed

### Database

Four tables are created by Liquibase changeset `00028-ogcapi-config.xml`. On first startup all rows are automatically seeded from the YAML config — no manual DB work needed.

**`ogcapi_property_mapping`** — one row, holds top-level settings and the update counter

| Column | Type | Description |
|---|---|---|
| `id` | `VARCHAR(255)` PK | Always `"property-mapping"` |
| `default_bucket_count` | `INTEGER` | Default number of facet buckets |
| `update_sequence` | `BIGINT` | Increments on every admin update |

**`ogcapi_field_mapping`** — one row per configured OGC API field

| Column | Type | Description |
|---|---|---|
| `id` | `BIGINT` PK | Auto-generated |
| `config_id` | `VARCHAR(255)` FK | → `ogcapi_property_mapping.id` |
| `sort_order` | `INTEGER` | Preserves field ordering |
| `ogc_property` | `VARCHAR(255)` | OGC property name exposed in the API |
| `elastic_property` | `VARCHAR(255)` | Dot-path into the Elasticsearch index |
| `index_record_property` | `VARCHAR(255)` | Dot-path into `IndexRecord` object |
| `type_override` | `VARCHAR(50)` | Optional type override (e.g. `LIST_STRING`) |
| `sort_field_suffix` | `VARCHAR(255)` | Suffix appended when used as a sort field |
| `is_sortable` | `BOOLEAN` | Expose in `/sortables` |
| `is_queryable` | `BOOLEAN` | Expose in `/queryables` |
| `title` | `VARCHAR(255)` | Human-readable label |
| `description` | `TEXT` | Human-readable description |
| `add_property_to_output` | `BOOLEAN` | Include value in record JSON output |

**`ogcapi_facet_config`** — one row per facet per field

| Column | Type | Description |
|---|---|---|
| `id` | `BIGINT` PK | Auto-generated |
| `field_mapping_id` | `BIGINT` FK | → `ogcapi_field_mapping.id` |
| `sort_order` | `INTEGER` | Preserves facet ordering within a field |
| `facet_name` | `VARCHAR(255)` | Name shown in the facets response |
| `facet_type` | `VARCHAR(50)` | `TERM`, `HISTOGRAM_FIXED_BUCKET_COUNT`, `HISTOGRAM_FIXED_INTERVAL`, or `FILTER` |
| `bucket_sorting` | `VARCHAR(50)` | `COUNT` or `VALUE` |
| `bucket_sorting_direction` | `VARCHAR(50)` | `ASCENDING` or `DESCENDING` |
| `bucket_count` | `INTEGER` | Max number of buckets |
| `minimum_document_count` | `INTEGER` | Buckets with fewer docs are hidden (default 1) |
| `number_bucket_interval` | `DOUBLE PRECISION` | Histogram interval for numeric fields |
| `calendar_interval_unit` | `VARCHAR(50)` | Histogram interval for date fields (`year`, `month`, …) |

**`ogcapi_filter_facet`** — one row per filter entry (only for `FILTER`-type facets)

| Column | Type | Description |
|---|---|---|
| `id` | `BIGINT` PK | Auto-generated |
| `facet_config_id` | `BIGINT` FK | → `ogcapi_facet_config.id` |
| `sort_order` | `INTEGER` | Preserves filter ordering within a facet |
| `filter_name` | `VARCHAR(255)` | Display name of the filter |
| `filter_equation_cql` | `TEXT` | CQL expression that defines the filter |

**Entity-Relationship Diagram**

```mermaid
erDiagram
    ogcapi_property_mapping {
        varchar id PK
        integer default_bucket_count
        bigint  update_sequence
    }

    ogcapi_field_mapping {
        bigint  id PK
        varchar config_id FK
        integer sort_order
        varchar ogc_property
        varchar elastic_property
        varchar index_record_property
        varchar type_override
        varchar sort_field_suffix
        boolean is_sortable
        boolean is_queryable
        varchar title
        text    description
        boolean add_property_to_output
    }

    ogcapi_facet_config {
        bigint  id PK
        bigint  field_mapping_id FK
        integer sort_order
        varchar facet_name
        varchar facet_type
        varchar bucket_sorting
        varchar bucket_sorting_direction
        integer bucket_count
        integer minimum_document_count
        double  number_bucket_interval
        varchar calendar_interval_unit
    }

    ogcapi_filter_facet {
        bigint  id PK
        bigint  facet_config_id FK
        integer sort_order
        varchar filter_name
        text    filter_equation_cql
    }

    ogcapi_property_mapping ||--o{ ogcapi_field_mapping : "has fields"
    ogcapi_field_mapping    ||--o{ ogcapi_facet_config   : "has facets"
    ogcapi_facet_config     ||--o{ ogcapi_filter_facet   : "has filters"
```

### New files

| File | Purpose |
|---|---|
| `src/shared/domain/.../OgcApiPropertyMapping.java` | JPA entity for `ogcapi_property_mapping` |
| `src/shared/domain/.../OgcApiFieldMapping.java` | JPA entity for `ogcapi_field_mapping` |
| `src/shared/domain/.../OgcApiFacetConfig.java` | JPA entity for `ogcapi_facet_config` |
| `src/shared/domain/.../OgcApiFilterFacet.java` | JPA entity for `ogcapi_filter_facet` |
| `src/shared/domain/.../repository/OgcApiPropertyMappingRepository.java` | JPA repository |
| `src/shared/ogcapi-records/.../OgcApiConfigChangedEvent.java` | Spring event fired on config update |
| `src/shared/ogcapi-records/.../OgcApiPropertyMappingService.java` | Service — seed, read, update config |
| `src/modules/ogcapi-records/.../OgcApiConfigController.java` | Admin REST endpoints |
| `src/shared/database/.../00028-ogcapi-config.xml` | Liquibase changeset (4 tables) |

### Modified files

| File | What changed |
|---|---|
| `OgcElasticFieldsMapperConfig.java` | `@Configuration` → `@Component` (removes CGLIB proxy so Jackson can serialize it) |
| `DynamicPropertiesFacade.java` | Loads config from `OgcApiPropertyMappingService` on startup; reloads on `OgcApiConfigChangedEvent` |
| `ElasticTypingSystem.java` | Added `refresh(newConfig)` to rebuild type maps; maps made `volatile` for thread safety |

---

## REST endpoints

Base path: `/api/ogcapi/configuration`

| Method | Path | Auth | Description |
|---|---|---|---|
| `GET` | `/api/ogcapi/configuration` | Admin | Return current config as JSON |
| `PUT` | `/api/ogcapi/configuration` | Admin | Replace config, increment sequence, reload in-memory cache |
| `GET` | `/api/ogcapi/configuration/update-sequence` | None | Return current update sequence counter |

The `/update-sequence` endpoint is unauthenticated so external containers can poll it to detect
changes without a message queue.

---

## How it works

```
YAML (bootstrap)
    ↓  first startup only — OgcApiPropertyMappingService @PostConstruct
ogcapi_property_mapping / ogcapi_field_mapping / ogcapi_facet_config / ogcapi_filter_facet
    ↓  every request
OgcApiPropertyMappingService.getConfig()   (entity graph → POJO)
    ↓  cached in-memory
DynamicPropertiesFacade  ←  OgcApiConfigChangedEvent (fired on PUT)
    ↓
facets / queryables / sortables endpoints
```

1. On startup, if no `property-mapping` row exists, the YAML config is mapped to the entity graph and inserted across all four tables.
2. `DynamicPropertiesFacade` loads config from the DB at startup via `@PostConstruct`.
3. When an admin calls `PUT /api/ogcapi/configuration`, the service clears the existing entity graph, rebuilds it from the new config, increments
   `update_sequence`, and fires `OgcApiConfigChangedEvent`.
4. `DynamicPropertiesFacade` listens for the event and reloads its cached config. It also calls
   `ElasticTypingSystem.refresh()` to rebuild the type maps.
5. All subsequent facet/queryable requests use the new config without a restart.

---

## Testing

**Unit tests**

```bash
mvn -pl src/shared/ogcapi-records test -Dtest=OgcApiPropertyMappingServiceTest
```

**Manual — with a running app (default port 7979, context path `/geonetwork`)**

```bash
# Check update sequence (no auth needed)
curl http://localhost:7979/geonetwork/api/ogcapi/configuration/update-sequence

# Sign in and save session cookie
curl -c /tmp/gn.cookies -X POST http://localhost:7979/geonetwork/api/user/signin \
  -d "username=admin&password=<password>"

# Get current config
curl -b /tmp/gn.cookies http://localhost:7979/geonetwork/api/ogcapi/configuration

# Update config (round-trip example — pipes GET response into PUT)
curl -b /tmp/gn.cookies http://localhost:7979/geonetwork/api/ogcapi/configuration \
  | curl -b /tmp/gn.cookies -X PUT \
      http://localhost:7979/geonetwork/api/ogcapi/configuration \
      -H "Content-Type: application/json" -d @-

# Confirm sequence incremented
curl http://localhost:7979/geonetwork/api/ogcapi/configuration/update-sequence
```