### PR TITLE
OGC API / Remove duplicated root links from LandingPageLinks

### DIFF
--- a/src/shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/links/LandingPageLinks.java
+++ b/src/shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/links/LandingPageLinks.java
@@ -33,7 +33,6 @@ public class LandingPageLinks extends BasicLinks {
         addOpenApiLink(landingPage);
         addIconLink(landingPage, catalogUuid);
         addConformanceLinks(landingPage);
-        addRootLinks(requestMediaTypeAndProfile, landingPage);
         collectionsPageLinks.addLinks(requestMediaTypeAndProfile, landingPage);
     }
 


### PR DESCRIPTION
## Description

The landing page is the root, so no need to add them 2 times.

## Type of Change
Select one:
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
Closes/updates # (optional):

## Approach

See https://github.com/geonetwork/geonetwork/blob/dev/src/shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/links/BasicLinks.java#L191-L193


## How to Verify

Check links in http://localhost:7979/geonetwork/api/?f=application/json 


<img width="1028" height="1224" alt="image" src="https://github.com/user-attachments/assets/ce76b435-371b-4933-87b3-0e0b790a78b5" />


## Checklist
- [ ] Code is formatted and linted
- [ ] All tests pass locally and in CI
- [ ] Tests updated (if applicable)
- [ ] Documentation updated (if applicable)

<!--
Optional: add any extra notes, credits (e.g., "Funded by ..."), or dependencies.
-->
