### PR TITLE
Bug Fix: Sort fields return HTTP 500

### DIFF
--- a/src/modules/ogcapi-records/ogcapi-records-implementation/src/main/java/org/geonetwork/ogcapi/controllerexceptions/GlobalExceptionHandler.java
+++ b/src/modules/ogcapi-records/ogcapi-records-implementation/src/main/java/org/geonetwork/ogcapi/controllerexceptions/GlobalExceptionHandler.java
@@ -50,6 +50,22 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<OgcApiRecordsExceptionDto>(exception, HttpStatusCode.valueOf(e.getCode()));
     }
 
+    /**
+     * Handle InvalidParameterException - a request with an unsupported parameter value (e.g. an unknown sortby
+     * property).
+     *
+     * @param e InvalidParameterException (client error)
+     * @return ResponseEntity<OgcApiRecordsExceptionDto> with message and status code 400
+     */
+    @ExceptionHandler(value = InvalidParameterException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<OgcApiRecordsExceptionDto> handleException(InvalidParameterException e) {
+        log.debug(e.getMessage(), e);
+        OgcApiRecordsExceptionDto exception =
+                new OgcApiRecordsExceptionDto().code("400").description(e.getMessage());
+        return new ResponseEntity<OgcApiRecordsExceptionDto>(exception, HttpStatusCode.valueOf(400));
+    }
+
     @ExceptionHandler(value = Exception.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public ResponseEntity<OgcApiRecordsExceptionDto> handleException(Exception e) {

--- a/src/modules/ogcapi-records/ogcapi-records-openapi-autogen/src/main/java/org/geonetwork/ogcapi/controllerexceptions/InvalidParameterException.java
+++ b/src/modules/ogcapi-records/ogcapi-records-openapi-autogen/src/main/java/org/geonetwork/ogcapi/controllerexceptions/InvalidParameterException.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: 2001 FAO-UN and others <geonetwork@osgeo.org>
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+package org.geonetwork.ogcapi.controllerexceptions;
+
+/**
+ * Thrown when a request contains a parameter value that is not supported (e.g. an unknown sortby/queryable property).
+ * Unchecked so it can propagate through functional interfaces (e.g. Elasticsearch query builder lambdas) that don't
+ * declare checked exceptions.
+ */
+public class InvalidParameterException extends RuntimeException {
+
+    public InvalidParameterException(String message) {
+        super(message);
+    }
+}

--- a/src/shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/search/RecordsEsQueryBuilder.java
+++ b/src/shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/search/RecordsEsQueryBuilder.java
@@ -14,6 +14,7 @@ import co.elastic.clients.elasticsearch._types.query_dsl.QueryStringQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.TermsQuery;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.search.SourceConfig;
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -24,6 +25,7 @@ import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.elasticsearch.geometry.Rectangle;
+import org.geonetwork.ogcapi.controllerexceptions.InvalidParameterException;
 import org.geonetwork.ogcapi.records.generated.model.OgcApiRecordsGnElasticDto;
 import org.geonetwork.ogcapi.service.configuration.OgcApiSearchConfiguration;
 import org.geonetwork.ogcapi.service.cql.CqlToElasticSearch;
@@ -120,11 +122,15 @@ public class RecordsEsQueryBuilder {
                 var isDescending = order.startsWith("-");
                 var sortOrder = isDescending ? SortOrder.Desc : SortOrder.Asc;
                 var fieldName = order.replaceAll("^[\\+-]", "");
-                var userconfig = this.dynamicPropertiesFacade.getUserConfigByOgcProperty(fieldName);
 
                 String elasticFieldName = "uuid";
                 if (!fieldName.equals("id")) {
                     // TODO: don't hardcode this - see  OgcApiCollectionsApi
+                    var userconfig = this.dynamicPropertiesFacade.getUserConfigByOgcProperty(fieldName);
+                    if (userconfig == null) {
+                        throw new InvalidParameterException(MessageFormat.format(
+                                "Cannot sort by ''{0}'' - it is not a configured sortable property.", fieldName));
+                    }
                     var elasticPropertyName = userconfig.getElasticProperty();
                     if (StringUtils.isNotEmpty(userconfig.getSortFieldSuffix())) {
                         elasticPropertyName += "." + userconfig.getSortFieldSuffix();


### PR DESCRIPTION
# Bug: sorting fails for certain fields in `GET /ogcapi-records/collections/{catalogId}/items`

Sort fields other than createDate return HTTP 500. Only createDate and -createDate work.
 #185
 
## The bug

`sortby` works fine for some fields (e.g. `sortby=resourceType`) but crashes with a `500` for others (e.g. `sortby=language`):

```json
{
  "code": "500",
  "description": "Cannot invoke \"org.geonetwork.ogcapi.service.configuration.OgcElasticFieldMapperConfig.getElasticProperty()\" because \"userconfig\" is null"
}
```

Only some fields are "not working" while sorting — not because of a bug in the sorting logic itself, but because those fields were never registered as sortable in the first place. Below is why that distinction exists, followed by the fix.

## Why only certain fields work

`sortby` is handled in `RecordsEsQueryBuilder.buildSearchRequest()` (`shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/search/RecordsEsQueryBuilder.java:114`). For each `sortby` entry it needs to resolve the OGC property name (e.g. `language`) to a real Elasticsearch field name to sort on. That resolution goes through `DynamicPropertiesFacade.getUserConfigByOgcProperty(fieldName)`, which looks the name up in a **sortable-fields config** — a list maintained independently of the rest of the API.

That config is not hardcoded in Java. It's seeded from YAML into the database on first boot:

```
config/application-ogcapi-records.yml
  geonetwork.openapi-records.ogcapi-property-mapping.fields:
    - ogcProperty: resourceType
      isSortable: true
      ...
```

Flow: `OgcElasticFieldsMapperConfig` (bound from that YAML) → `OgcApiPropertyMappingService` seeds it into the DB → `DynamicPropertiesFacade` loads it at startup (and reloads on config-change events) → `getUserConfigByOgcProperty(name)` is a lookup against this loaded config.

**Only 7 fields are currently in that list** (confirm live via `GET /ogcapi-records/collections/{catalogId}/sortables`, built by `SortablesService.createProperties()`):

| `sortby` value | Source |
|---|---|
| `id` | hardcoded in `RecordsEsQueryBuilder`, sorts by ES field `uuid` |
| `resourceType` | `isSortable: true` in YAML |
| `updateFrequency` | `isSortable: true` in YAML |
| `creationYearForResource` | `isSortable: true` in YAML |
| `createDate` | `isSortable: true` in YAML |
| `resourceTitleObject` | `isSortable: true` in YAML |
| `resolutionScaleDenominator` | `isSortable: true` in YAML |

Anything not in this list, has no entry to resolve, by design. 

## The bug fix: from crash (500) to proper error (400)

Requesting an unsupported field should be a client error (bad `sortby` value), not a server crash. Before the fix, the code assumed the lookup always succeeds and dereferenced the result unconditionally:

```java
var userconfig = this.dynamicPropertiesFacade.getUserConfigByOgcProperty(fieldName);
...
var elasticPropertyName = userconfig.getElasticProperty(); // NPE when userconfig == null
```

`getUserConfigByOgcProperty` returns `null` whenever the field isn't in the sortable-fields config — which is exactly the `language` case (and any misspelled or otherwise unsupported field). The missing null check let a `NullPointerException` escape uncaught, and `GlobalExceptionHandler`'s catch-all `Exception` handler turned that into an opaque `500 Internal Server Error` with a raw stack-trace message.

The fix makes this an intentional, well-formed `400` instead:

1. **`RecordsEsQueryBuilder.buildSearchRequest()`** now null-checks the lookup and throws a descriptive error instead of crashing:

   ```java
   var userconfig = this.dynamicPropertiesFacade.getUserConfigByOgcProperty(fieldName);
   if (userconfig == null) {
       throw new InvalidParameterException(MessageFormat.format(
               "Cannot sort by ''{0}'' - it is not a configured sortable property.", fieldName));
   }
   ```

2. **New `InvalidParameterException`** (`ogcapi-records-openapi-autogen/.../controllerexceptions/InvalidParameterException.java`) — an **unchecked** `RuntimeException`. It has to be unchecked (unlike the existing `NotFoundException`/`GenericOgcApiException`, which are checked) because it's thrown from inside a `forEach` lambda and an Elasticsearch query-builder `Function`, neither of which can declare checked exceptions — it needs to propagate up to Spring without being wrapped or swallowed along the way.

3. **`GlobalExceptionHandler`** (`ogcapi-records-implementation/.../controllerexceptions/GlobalExceptionHandler.java`) — added `@ExceptionHandler(InvalidParameterException.class)` mapping it to HTTP `400`, instead of letting it fall through to the generic `500` handler.

### Result

```
GET .../items?sortby=language
```

now returns:

```json
{
  "code": "400",
  "description": "Cannot sort by 'language' - it is not a configured sortable property."
}
```

instead of a `500` with an internal NPE message.

### Note

This fix corrects the *failure mode* (400 vs 500) — it does not add `language` to the sortable list. If `language` should actually become sortable, that requires adding an entry for it under `geonetwork.openapi-records.ogcapi-property-mapping.fields` in `config/application-ogcapi-records.yml` (e.g. mapped to the ES field `mainLanguage`, with `isSortable: true`), which is a separate, deliberate configuration change rather than a bug fix.
