### PR TITLE
JWTSigning issue on Windows due to CRLF line endings

### DIFF
--- a/src/modules/geonetwork4/src/main/java/org/geonetwork/gn4/security/JwtSigning.java
+++ b/src/modules/geonetwork4/src/main/java/org/geonetwork/gn4/security/JwtSigning.java
@@ -52,7 +52,7 @@ public class JwtSigning {
             privateKeyBase64 = privateKeyBase64.replace("-----END PRIVATE KEY-----", "");
             privateKeyBase64 = privateKeyBase64.trim();
         }
-        privateKeyBase64 = privateKeyBase64.replace("\n", "").trim();
+        privateKeyBase64 = privateKeyBase64.replaceAll("\\s", "");
         byte[] privateKeyDecoded = Base64.getDecoder().decode(privateKeyBase64);
         PKCS8EncodedKeySpec pkcs8EncodedKeySpec = new PKCS8EncodedKeySpec(privateKeyDecoded);
         PrivateKey privateKey = KeyFactory.getInstance("RSA").generatePrivate(pkcs8EncodedKeySpec);


### PR DESCRIPTION

# JWTSigning issue on Windows due to CRLF line endings

## Description
JWTSigning issue on Windows due to CRLF line endings (git's autocrlf conversion). JwtSigning.getPrivateKey only stripped \n, leaving  \r  in the base64 payload. Replace the \n strip with replaceAll("\\s", ""), which removes all whitespace characters.

## Type of Change
Select one:
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring


## Approach
Remove all whitespacecharacters when loading the private key instead of removing only '\r' characters.