### PR TITLE
Fix: Ogc api records ignores cql negation

### DIFF
--- a/src/shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/cql/ImprovedCqlFilter2Elastic.java
+++ b/src/shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/cql/ImprovedCqlFilter2Elastic.java
@@ -73,6 +73,28 @@ public class ImprovedCqlFilter2Elastic extends AbstractFilterVisitor {
 
     @Override
     public Object visit(PropertyIsEqualTo filter, Object extraData) {
+        stack.push(buildEqualsQuery(filter, extraData));
+        return this;
+    }
+
+    @Override
+    public Object visit(PropertyIsNotEqualTo filter, Object extraData) {
+        var equalsQuery = buildEqualsQuery(filter, extraData);
+        stack.push(Query.of(q -> q.bool(b -> b.mustNot(equalsQuery))));
+        return this;
+    }
+
+    @Override
+    public Object visit(Not filter, Object extraData) {
+        filter.getFilter().accept(this, extraData);
+
+        var negatedQuery = (Query) stack.pop();
+
+        stack.push(Query.of(q -> q.bool(b -> b.mustNot(negatedQuery))));
+        return this;
+    }
+
+    private Query buildEqualsQuery(BinaryComparisonOperator filter, Object extraData) {
         checkFilterExpressionsInBinaryComparisonOperator(filter);
 
         filter.getExpression1().accept(expressionVisitor, extraData);
@@ -85,10 +107,7 @@ public class ImprovedCqlFilter2Elastic extends AbstractFilterVisitor {
         final var _dataPropertyValue = dataPropertyValue;
 
         //        var query = Query.of(q -> q.term(tq -> tq.field(dataPropertyName).value(_dataPropertyValue)));
-        var query = Query.of(q -> q.term(tq -> tq.field(dataPropertyName).value(_dataPropertyValue)));
-
-        stack.push(query);
-        return this;
+        return Query.of(q -> q.term(tq -> tq.field(dataPropertyName).value(_dataPropertyValue)));
     }
 
     @Override

--- a/src/shared/ogcapi-records/src/test/java/org/geonetwork/ogcapi/service/cql/ImprovedCqlFilter2ElasticTest.java
+++ b/src/shared/ogcapi-records/src/test/java/org/geonetwork/ogcapi/service/cql/ImprovedCqlFilter2ElasticTest.java
@@ -96,6 +96,33 @@ public class ImprovedCqlFilter2ElasticTest {
         assertEquals("5", result.range().untyped().lte().toString());
         assertNull(result.range().untyped().gt());
         assertNull(result.range().untyped().lt());
+
+        result = doIt("dave <> 'hi'", new TrivialFieldMapper());
+        assertEquals(Query.Kind.Bool, result._kind());
+        assertEquals(1, ((BoolQuery) result._get()).mustNot().size());
+        var notEqualsInner = ((BoolQuery) result._get()).mustNot().get(0);
+        assertEquals(Query.Kind.Term, notEqualsInner._kind());
+        assertEquals("__dave", ((TermQuery) notEqualsInner._get()).field());
+        assertEquals("hi", ((TermQuery) notEqualsInner._get()).value().stringValue());
+
+        result = doIt("not (dave = 'hi')", new TrivialFieldMapper());
+        assertEquals(Query.Kind.Bool, result._kind());
+        assertEquals(1, ((BoolQuery) result._get()).mustNot().size());
+        var notInner = ((BoolQuery) result._get()).mustNot().get(0);
+        assertEquals(Query.Kind.Term, notInner._kind());
+        assertEquals("__dave", ((TermQuery) notInner._get()).field());
+        assertEquals("hi", ((TermQuery) notInner._get()).value().stringValue());
+
+        result = doIt("(dave = 'hi') and (not (dave2 = 'bob'))", new TrivialFieldMapper());
+        assertEquals(Query.Kind.Bool, result._kind());
+        var mustClauses = ((BoolQuery) result._get()).must();
+        assertEquals(2, mustClauses.size());
+        assertEquals(
+                1,
+                mustClauses.stream().filter(q -> q._kind() == Query.Kind.Term).count());
+        assertEquals(
+                1,
+                mustClauses.stream().filter(q -> q._kind() == Query.Kind.Bool).count());
     }
 
     public Query doIt(String cqlText, IFieldMapper fieldMapper) throws CQLException {


### PR DESCRIPTION
# Fix: OGC API Records ignores CQL negation (`NOT`, `<>`)

Fixes [geonetwork/geonetwork#189](https://github.com/geonetwork/geonetwork/issues/189).

## Symptom

`GET /geonetwork/ogcapi-records/collections/{id}/items?filter=...` silently dropped negation:

| `filter=` | returned | expected |
| --- | --- | --- |
| `NOT (resourceType = 'dataset')` | same as `resourceType = 'dataset'` | the inverse set |
| `resourceType <> 'dataset'` | same as `resourceType = 'dataset'` | the inverse set |

No error was returned (HTTP 200), so clients had no way to detect that the filter was silently wrong.

## Root cause

`ImprovedCqlFilter2Elastic` (`src/shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/cql/ImprovedCqlFilter2Elastic.java`)
is a GeoTools `AbstractFilterVisitor` that walks a parsed CQL filter and pushes Elasticsearch `Query`
objects onto a shared stack (`must`/`should`/`term`/`range`, etc.). It had overrides for `PropertyIsEqualTo`,
`PropertyIsLike`, range comparisons, `PropertyIsBetween`, `And`, and `Or` — but **no override for `Not` or
`PropertyIsNotEqualTo`**.

Without an override, GeoTools falls back to `AbstractFilterVisitor`'s default behavior:

- **`Not`**: the default implementation just visits the child filter and discards the wrapper. Since our
  visitor builds queries by pushing onto a shared stack as a side effect, the child's query still ended up
  on the stack — as if the `NOT` had never been there.
- **`PropertyIsNotEqualTo` (`<>`)**: the default delegates to a shared expression-visitor mechanism that our
  subclass doesn't actually wire up for this path, so the clause pushed *nothing* onto the stack. A
  standalone `<>` filter silently evaluated to "match everything"; inside `AND`/`OR` it could pop the wrong
  sibling's query off the stack and corrupt the whole compound filter.

## Fix

Added the two missing overrides in `ImprovedCqlFilter2Elastic`:

```java
@Override
public Object visit(Not filter, Object extraData) {
    filter.getFilter().accept(this, extraData);
    var negatedQuery = (Query) stack.pop();
    stack.push(Query.of(q -> q.bool(b -> b.mustNot(negatedQuery))));
    return this;
}

@Override
public Object visit(PropertyIsNotEqualTo filter, Object extraData) {
    var equalsQuery = buildEqualsQuery(filter, extraData);
    stack.push(Query.of(q -> q.bool(b -> b.mustNot(equalsQuery))));
    return this;
}
```

`PropertyIsEqualTo`'s query-building logic was extracted into a shared `buildEqualsQuery(...)` helper so
`<>` reuses the exact same term-query construction, just wrapped in `bool.must_not`.

### Multi-valued fields

The issue also asked to confirm behavior on multi-valued fields (`resourceType`, `tags`, `format`,
`orgForResource`, `spatialRepresentationType`): excluding value `V` should mean "no element of the array
equals `V`", not "some element differs from `V`".

No special-casing was needed. Elasticsearch `term` queries on array/keyword-list fields already match if
*any* element equals the value, so wrapping that same query in `bool.must_not` correctly negates to "no
element equals the value" — exactly the semantics the issue asked for.

## Tests

Added cases to `ImprovedCqlFilter2ElasticTest.java` covering:

- `dave <> 'hi'` → `bool.must_not` wrapping a `term` query
- `not (dave = 'hi')` → `bool.must_not` wrapping a `term` query
- `(dave = 'hi') and (not (dave2 = 'bob'))` → `bool.must` with one `term` and one nested `bool` clause
