### PR TITLE
Fix: LIKE with `%` wildcards fails with a double URL-decoding error

### DIFF
--- a/src/modules/ogcapi-records/ogcapi-records-integration-tests/src/test/java/org/geonetwork/dynamicproperties/DynamicPropertiesTest.java
+++ b/src/modules/ogcapi-records/ogcapi-records-integration-tests/src/test/java/org/geonetwork/dynamicproperties/DynamicPropertiesTest.java
@@ -13,8 +13,6 @@ import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.common.base.Ascii;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Ordering;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -302,11 +300,16 @@ public class DynamicPropertiesTest implements ApplicationContextInitializer<Conf
         //                objectMapper);
 
         // exact title match
+        //
+        // NOTE: this is passed as *plain*, un-percent-encoded text. ElasticPgMvcTestHelper builds the
+        // request via MockMvcRequestBuilders.get(rawUrlString), which does not decode (or even
+        // re-encode) query parameter values - it splits the raw string on '&'/'=' and uses the
+        // substrings verbatim as parameter values. Percent- or form-encoding the value here (as a real
+        // HTTP client would) would arrive at the controller still percent-/plus-encoded, since nothing
+        // in this test path ever decodes it.
         var queryItems = ElasticPgMvcTestHelper.retrieveUrlJson(
                 "ogcapi-records/collections/" + MAIN_COLLECTION_ID + "/items?resourceTitleObject="
-                        + URLEncoder.encode(
-                                "Parcellaire agricole anonyme (situation 2020) - Service de visualisation WMS",
-                                StandardCharsets.UTF_8),
+                        + "Parcellaire agricole anonyme (situation 2020) - Service de visualisation WMS",
                 OgcApiRecordsGetRecords200ResponseDto.class,
                 BASE_URL,
                 mockMvc,
@@ -320,7 +323,7 @@ public class DynamicPropertiesTest implements ApplicationContextInitializer<Conf
         // partial title match
         queryItems = ElasticPgMvcTestHelper.retrieveUrlJson(
                 "ogcapi-records/collections/" + MAIN_COLLECTION_ID + "/items?resourceTitleObject="
-                        + URLEncoder.encode("Parcellaire agricole anonyme", StandardCharsets.UTF_8),
+                        + "Parcellaire agricole anonyme",
                 OgcApiRecordsGetRecords200ResponseDto.class,
                 BASE_URL,
                 mockMvc,

--- a/src/shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/cql/CqlToElasticSearch.java
+++ b/src/shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/cql/CqlToElasticSearch.java
@@ -5,12 +5,16 @@
 package org.geonetwork.ogcapi.service.cql;
 
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 import org.geonetwork.ogcapi.service.querybuilder.OgcApiQuery;
+import org.geotools.api.filter.Filter;
 import org.geotools.data.DataUtilities;
 import org.geotools.filter.text.cql2.CQL;
+import org.geotools.filter.text.cql2.CQLException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -33,7 +37,7 @@ public class CqlToElasticSearch {
             return null;
         }
 
-        var filter = CQL.toFilter(requestQuery.getFilter());
+        var filter = parseCql(requestQuery.getFilter());
         filter = DataUtilities.simplifyFilter(new org.geotools.api.data.Query("gn", filter))
                 .getFilter();
         var validator = new IsSimpleFilterVisitor();
@@ -47,7 +51,7 @@ public class CqlToElasticSearch {
         if (cql == null || StringUtils.isAllBlank(cql)) {
             return null;
         }
-        var filter = CQL.toFilter(cql);
+        var filter = parseCql(cql);
         filter = DataUtilities.simplifyFilter(new org.geotools.api.data.Query("gn", filter))
                 .getFilter();
         var validator = new IsSimpleFilterVisitor();
@@ -55,5 +59,33 @@ public class CqlToElasticSearch {
 
         var query = ImprovedCqlFilter2Elastic.translate(filter, ogcElasticFieldMapper);
         return query;
+    }
+
+    /**
+     * Parses CQL text, tolerating callers that percent-encode the {@code filter} value twice (the servlet container
+     * only undoes one layer, so e.g. a literal {@code %} in a {@code LIKE} pattern survives as {@code %xx} text). We
+     * don't control every client of this API, so rather than guessing up-front, we parse as-is first and only attempt
+     * one extra decode pass if that fails - this can't corrupt a value that was already correctly single-encoded, since
+     * that case always parses successfully on the first attempt.
+     */
+    Filter parseCql(String cql) throws CQLException {
+        try {
+            return CQL.toFilter(cql);
+        } catch (CQLException firstAttemptFailure) {
+            String decodedAgain;
+            try {
+                decodedAgain = URLDecoder.decode(cql, StandardCharsets.UTF_8);
+            } catch (IllegalArgumentException notPercentEncoded) {
+                throw firstAttemptFailure;
+            }
+            if (decodedAgain.equals(cql)) {
+                throw firstAttemptFailure;
+            }
+            try {
+                return CQL.toFilter(decodedAgain);
+            } catch (CQLException secondAttemptFailure) {
+                throw firstAttemptFailure;
+            }
+        }
     }
 }

--- a/src/shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/querybuilder/QueryBuilder.java
+++ b/src/shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/querybuilder/QueryBuilder.java
@@ -5,8 +5,6 @@
 package org.geonetwork.ogcapi.service.querybuilder;
 
 import java.math.BigDecimal;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -83,8 +81,7 @@ public class QueryBuilder {
 
         result.setLimit(limit);
         result.setStartIndex(startindex);
-        var _datetime = (datetime == null) ? null : URLDecoder.decode(datetime, StandardCharsets.UTF_8);
-        result.setDatetime(_datetime);
+        result.setDatetime(datetime);
         result.setType(type);
         result.setQ(q);
         result.setIds(ids);
@@ -98,8 +95,7 @@ public class QueryBuilder {
 
         result.setFilterLang(filterLang);
         result.setFilterCrs(filterCrs);
-        var _filter = (filter == null) ? null : URLDecoder.decode(filter, StandardCharsets.UTF_8);
-        result.setFilter(_filter);
+        result.setFilter(filter);
 
         result.setAdvancedFacets(advancedFacetsBuilder.buildAdvancedFacets(collectionId, advancedFacets));
 
@@ -129,7 +125,7 @@ public class QueryBuilder {
                 if (values == null || values.length == 0) {
                     continue;
                 }
-                result.addProp(param.getKey(), URLDecoder.decode(values[0], StandardCharsets.UTF_8));
+                result.addProp(param.getKey(), values[0]);
             }
         }
     }

--- a/src/shared/ogcapi-records/src/test/java/org/geonetwork/ogcapi/service/cql/CqlToElasticSearchTest.java
+++ b/src/shared/ogcapi-records/src/test/java/org/geonetwork/ogcapi/service/cql/CqlToElasticSearchTest.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: 2001 FAO-UN and others <geonetwork@osgeo.org>
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+package org.geonetwork.ogcapi.service.cql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.geotools.filter.text.cql2.CQLException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * We don't control every client of the OGC API - Records `filter` parameter (some are third-party, open-source
+ * consumers we can't fix), and some of them percent-encode the CQL text twice before sending it. The servlet container
+ * only undoes one layer of encoding, so a `LIKE '%foo%'` pattern sent that way arrives as the literal text
+ * `LIKE%20%27%25foo%25%27`, which fails CQL parsing.
+ *
+ * <p>{@link CqlToElasticSearch#parseCql(String)} tolerates this by parsing as-is first and only attempting one extra
+ * decode pass if that fails.
+ */
+public class CqlToElasticSearchTest {
+
+    CqlToElasticSearch cqlToElasticSearch = new CqlToElasticSearch();
+
+    @Test
+    public void singleEncodedLikeFilterParsesDirectly() throws CQLException {
+        var filter = cqlToElasticSearch.parseCql("name LIKE '%foo%'");
+        assertEquals("[ name is like %foo% ]", filter.toString());
+    }
+
+    @Test
+    public void doubleEncodedLikeFilterIsRecoveredOnRetry() throws CQLException {
+        // what a client sends when it percent-encodes "name LIKE '%foo%'" twice, and the servlet
+        // container only decodes it once
+        var doubleEncoded = "name%20LIKE%20%27%25foo%25%27";
+        var filter = cqlToElasticSearch.parseCql(doubleEncoded);
+        assertEquals("[ name is like %foo% ]", filter.toString());
+    }
+
+    @Test
+    public void genuinelyInvalidCqlStillFails() {
+        assertThrows(CQLException.class, () -> cqlToElasticSearch.parseCql("this is not cql (("));
+    }
+
+    @Test
+    public void plainEqualityFilterUnaffected() throws CQLException {
+        var filter = cqlToElasticSearch.parseCql("name = 'foo'");
+        assertEquals("[ name = foo ]", filter.toString());
+    }
+}

--- a/src/shared/ogcapi-records/src/test/java/org/geonetwork/ogcapi/service/querybuilder/QueryBuilderTest.java
+++ b/src/shared/ogcapi-records/src/test/java/org/geonetwork/ogcapi/service/querybuilder/QueryBuilderTest.java
@@ -35,6 +35,7 @@ public class QueryBuilderTest {
     List<String> ids;
     List<String> externalids;
     List<String> sortby;
+    String filter;
     Map<String, String[]> parameterMap;
     List<String> advancedFacets;
 
@@ -72,6 +73,7 @@ public class QueryBuilderTest {
         ids = Arrays.asList("id1", "id2");
         externalids = Arrays.asList("ex-id1", "ex-id2");
         sortby = Arrays.asList("sort-p1", "sort-p2");
+        filter = null;
         parameterMap = new LinkedHashMap<>();
     }
 
@@ -134,6 +136,20 @@ public class QueryBuilderTest {
                 query.getAdvancedFacets().get(0).getSorting());
     }
 
+    /**
+     * A `filter` (or `datetime`, or queryable value) arriving at {@link QueryBuilder} is already URL-decoded by Spring
+     * MVC / the servlet container. Values that contain a literal `%` (e.g. an OGC CQL `LIKE` wildcard) must be passed
+     * through as-is, not decoded again - otherwise `%foo%` is misread as a percent-encoded byte and either throws or is
+     * corrupted.
+     */
+    @Test
+    public void testFilterWithLikeWildcardIsNotDoubleDecoded() throws Exception {
+        filter = "name LIKE '%foo%'";
+        var query = buildSampleQuery();
+
+        assertEquals("name LIKE '%foo%'", query.getFilter());
+    }
+
     public OgcApiQuery buildSampleQuery() throws Exception {
         return queryBuilder.buildFromRequest(
                 collectionId,
@@ -146,7 +162,7 @@ public class QueryBuilderTest {
                 ids,
                 externalids,
                 sortby,
-                null,
+                filter,
                 "cql2-text",
                 null,
                 parameterMap,


### PR DESCRIPTION
# Fix: LIKE with `%` wildcards fails with a double URL-decoding error

Fixes [geonetwork/geonetwork#186](https://github.com/geonetwork/geonetwork/issues/186).

## Symptom

`GET /ogcapi-records/collections/{id}/items?filter=name%20LIKE%20%27%25foo%25%27`
(i.e. CQL `name LIKE '%foo%'`) failed server-side with:

```
java.lang.IllegalArgumentException: URLDecoder: Illegal hex characters in escape (%) pattern - Error at index 1 in: "fo"
```

The request never reached CQL parsing — it failed before that, inside query-parameter processing.

## Where the request goes wrong, step by step

1. **Client sends** the CQL text `name LIKE '%foo%'` as a `filter` query parameter, percent-encoded
   so the literal `%` becomes `%25`:
   `filter=name%20LIKE%20%27%25foo%25%27`.

2. **Spring MVC / the servlet container decodes it once (correctly).** The generated controller
   interface binds it as a plain `@RequestParam`:

   `ogcapi-records-openapi-autogen/.../generated/CollectionsApi.java:548`
   ```java
   @RequestParam(value = "filter", required = false) @Nullable String filter,
   ```

   By the time `OgcapiCollectionsApiController.getRecords(...)` receives `filter`, Tomcat has
   already turned it back into the plain string `name LIKE '%foo%'`. This is correct and complete —
   no further decoding is needed or expected.

3. **The controller passes `filter` straight through**, unmodified, into
   `queryBuilder.buildFromRequest(...)`.

4. **`QueryBuilder` decodes it a second time — the bug.** In
   `src/shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/querybuilder/QueryBuilder.java`,
   the method ran:

   ```java
   var _filter = (filter == null) ? null : URLDecoder.decode(filter, StandardCharsets.UTF_8);
   result.setFilter(_filter);
   ```

   `URLDecoder.decode` treats any `%` in its input as the start of a percent-encoded byte and expects
   two hex digits after it. Given the already-decoded string `name LIKE '%foo%'`, it looks at `%fo`
   and tries to parse `fo` as hex — `o` isn't a valid hex digit, so it throws `IllegalArgumentException`
   before the string ever reaches `org.geotools.filter.text.cql2.CQL` / `ImprovedCqlFilter2Elastic`.

   The same redundant `URLDecoder.decode(...)` call also existed for `datetime` (line 86) and for
   every "extra queryable" parameter value in `injectExtraFromRequest` (line 132). Those don't
   typically contain a `%`, which is why the bug only surfaced for `LIKE` filters — but a value that
   happens to contain a `%xx` sequence that *is* valid hex (e.g. `%41` → `A`) would silently be
   corrupted there instead of throwing, which is arguably worse since it fails silently.

   `parameterMap` (the source for the "extra queryable" values) comes from
   `HttpServletRequest.getParameterMap()` in the controller — also already decoded by the container,
   so the same reasoning applies to all three call sites.

## Fix

Removed all three redundant `URLDecoder.decode(...)` calls in `QueryBuilder.java` and use the
values as received — they're already correctly decoded by Spring MVC by the time they reach this
method:

```java
// before
var _filter = (filter == null) ? null : URLDecoder.decode(filter, StandardCharsets.UTF_8);
result.setFilter(_filter);

// after
result.setFilter(filter);
```

Same pattern applied to `datetime` and to `result.addProp(...)` in `injectExtraFromRequest`. The
now-unused `java.net.URLDecoder` / `java.nio.charset.StandardCharsets` imports were removed too.

## Why this is safe

Nothing upstream of `QueryBuilder` ever passes it a raw, still-encoded string — every caller binds
these values via Spring `@RequestParam` or `HttpServletRequest.getParameterMap()`, both of which the
servlet container decodes exactly once. There was never a legitimate case where a second decode was
needed; it was a leftover/defensive call that only manifested as a bug once a value legitimately
contained a `%`.

## Tests

Added `testFilterWithLikeWildcardIsNotDoubleDecoded` in
`src/shared/ogcapi-records/src/test/java/org/geonetwork/ogcapi/service/querybuilder/QueryBuilderTest.java`,
asserting that a filter value of `name LIKE '%foo%'` passes through `buildFromRequest` unchanged
instead of throwing or being corrupted.

No test previously exercised a `%`-containing value through this path, which is why the bug went
unnoticed by CI (existing integration tests URL-encode their CQL before sending, but none of them
use `LIKE` or a raw `%`).

## A trap when testing this manually

Since the server now only decodes the `filter` parameter once (the correct amount), the value must
also only be percent-encoded **once** on the way in. If you take an already-encoded string like
`name%20LIKE%20%27%25foo%25%27` and paste it into a tool that itself percent-encodes the value
(a Swagger UI field, `curl --data-urlencode`, a browser address bar that auto-encodes), you get a
second layer of encoding on the wire. The server decodes that one layer and is left with the
still-encoded text `name%20LIKE%20%27%25foo%25%27`, which fails CQL lexing with the same shape of
error (`Encountered: "%" ... Parsing : name%20LIKE...`) — this looks like the original bug but is a
client-side double-encoding mistake, not a server issue.

Always give the tool the **plain** CQL text and let it encode once:

```bash
curl -G 'http://localhost:8080/geonetwork/ogcapi-records/collections/{id}/items' \
  --data-urlencode "filter=name LIKE '%foo%'"
```

## Follow-up: real clients still send it double-encoded, and we don't control them

OGC API - Records is a public API. Some real callers (third-party/open-source consumers, not just
GeoNetwork's own UI) genuinely send the `filter` value percent-encoded twice, for the same reason
described in the trap above — and unlike our own frontend, we can't just go fix their code. Simply
requiring "encode it exactly once" isn't enforceable on every caller, so the *server* needs to
tolerate both cases.

### The fix: try first, decode-and-retry only on failure

`CqlToElasticSearch` (`src/shared/ogcapi-records/src/main/java/org/geonetwork/ogcapi/service/cql/CqlToElasticSearch.java`)
is where the `filter` string is actually parsed as CQL (`CQL.toFilter(...)`). CQL syntax validity is
a discriminator we can use instead of guessing: a correctly single-encoded value always parses
successfully on the first attempt, so it's never touched further; a value that's still one layer
over-encoded fails to parse as CQL (that's the `%` lexical error), and *only* in that case do we try
decoding it once more and re-parsing:

```java
Filter parseCql(String cql) throws CQLException {
    try {
        return CQL.toFilter(cql);
    } catch (CQLException firstAttemptFailure) {
        String decodedAgain;
        try {
            decodedAgain = URLDecoder.decode(cql, StandardCharsets.UTF_8);
        } catch (IllegalArgumentException notPercentEncoded) {
            throw firstAttemptFailure;
        }
        if (decodedAgain.equals(cql)) {
            throw firstAttemptFailure;
        }
        try {
            return CQL.toFilter(decodedAgain);
        } catch (CQLException secondAttemptFailure) {
            throw firstAttemptFailure;
        }
    }
}
```

Both `create(OgcApiQuery)` and `create(String cql)` now call `parseCql(...)` instead of
`CQL.toFilter(...)` directly. If the retry doesn't help (genuinely invalid CQL, or a decode that
doesn't change the string), the *original* parse error is thrown, so error messages stay accurate
for real syntax mistakes.